### PR TITLE
[FEAT]: Mission control system — delivery missions, annotated points,…

### DIFF
--- a/Docs/CONTEXT_MISSION.md
+++ b/Docs/CONTEXT_MISSION.md
@@ -1,0 +1,81 @@
+# Health Robot
+
+Ce contexte décrit le langage métier des missions de livraison opérées par le robot en établissement de soins. Il sert à distinguer clairement les demandes humaines, les trajets robot, les points métier et les validations de livraison.
+
+## Language
+
+**Aide-soignant**:
+Utilisateur opérationnel qui crée des demandes de mission pour faire livrer des fournitures à sa chambre ou à sa zone de travail.
+_Avoid_: utilisateur simple, soignant, client
+
+**Administrateur**:
+Utilisateur autorisé à tester, vérifier, maintenir et exécuter les actions sensibles du robot en plus des actions opérationnelles.
+_Avoid_: super utilisateur, technicien, owner
+
+**Fourniture**:
+Objet consommable ou matériel courant que le robot peut transporter pour l'équipe soignante, limité pour l'instant aux serviettes, papier toilette, gants, protections et linge.
+_Avoid_: matériel médical, médicament, colis
+
+**Demande de mission**:
+Demande créée par un aide-soignant ou un administrateur pour faire récupérer une fourniture à un point de stock et la livrer à une chambre.
+_Avoid_: commande, ordre, ticket
+
+**Mission de livraison**:
+Exécution robot d'une demande de mission, depuis la base vers un point de stock, puis vers la chambre de livraison.
+_Avoid_: navigation libre, trajet, course
+
+**Mission enchaînée**:
+Mission de livraison exécutée après une autre mission sans retour préalable à la base. Le robot repart depuis sa position courante, généralement une chambre de livraison.
+_Avoid_: tournée automatique, boucle, multi-trajet
+
+**File de missions**:
+Ensemble ordonné des missions de livraison en attente d'exécution par le robot. La file permet de créer de nouvelles demandes pendant qu'une mission est déjà en cours.
+_Avoid_: tournée optimisée, backlog technique, liste personnelle
+
+**Mission active**:
+Unique mission de livraison actuellement exécutée ou attendue par le robot. Une mission active peut être en navigation, en attente de récupération ou en attente de confirmation de livraison.
+_Avoid_: toutes les missions ouvertes, commande robot active, tâche courante
+
+**Point annoté**:
+Point nommé et réutilisable sur la carte, représentant un lieu métier tel qu'un stock, une chambre de livraison ou une base robot.
+_Avoid_: waypoint brut, pin, marqueur temporaire
+
+**Point de stock**:
+Point annoté où une fourniture peut être récupérée par le robot. Il peut exister plusieurs points de stock.
+_Avoid_: base, réserve unique, entrepôt
+
+**Règle de stock**:
+Règle qui associe une fourniture au point de stock que le robot doit rejoindre pour la récupérer.
+_Avoid_: choix manuel du stock, routage libre, mapping technique
+
+**Chambre de livraison**:
+Chambre associée à la demande de mission, où la fourniture doit être livrée à l'aide-soignant.
+_Avoid_: destination libre, client, point final
+
+**Base robot**:
+Point annoté où le robot attend ses missions et où il peut être renvoyé après une livraison.
+_Avoid_: origine carte, station, maison
+
+**Récupération de fourniture**:
+Étape pendant laquelle le robot obtient la fourniture au point de stock. Cette étape est une vraie action métier, même si sa détection automatique sera implémentée plus tard.
+_Avoid_: chargement manuel, pick technique, scan
+
+**Attente de récupération**:
+État temporaire d'une mission lorsque le robot est arrivé au point de stock et attend que la récupération de fourniture soit confirmée ou automatisée.
+_Avoid_: pause, blocage, chargement manuel
+
+**Confirmation de livraison**:
+Validation humaine effectuée après l'arrivée du robot à la chambre de livraison pour confirmer que la fourniture a été remise.
+_Avoid_: arrivée robot, mission terminée automatiquement
+
+**Annulation de mission**:
+Décision humaine d'arrêter une mission de livraison avant sa fin. Elle ne signifie pas automatiquement que le robot retourne à la base.
+_Avoid_: retour base, échec technique, arrêt d'urgence
+
+**Retour base**:
+Action qui renvoie le robot à sa base après une livraison ou entre deux missions, à la décision de l'utilisateur.
+_Avoid_: retour maison, reset, annulation
+
+**Écran robot**:
+Interface visible sur l'écran embarqué du robot, destinée aux personnes proches du robot. Elle affiche l'état courant du robot et revient à une identité simple CareBot lorsque le robot est à la base et inactif.
+_Avoid_: dashboard admin, écran technique, console robot

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -7,10 +7,10 @@ from sqlalchemy import engine_from_config, pool
 
 from app.core.config import settings
 from app.infrastructure.database.base import Base
-from app.infrastructure.database.models import RobotSettingsModel, UserModel
+from app.infrastructure.database.models import AnnotatedPointModel, MissionModel, RobotSettingsModel, StockPointSupplyModel, UserModel
 
 # Import models so SQLAlchemy metadata is populated for autogeneration.
-_ = (RobotSettingsModel, UserModel)
+_ = (AnnotatedPointModel, MissionModel, RobotSettingsModel, StockPointSupplyModel, UserModel)
 
 config = context.config
 

--- a/backend/alembic/versions/20260619_0004_create_mission_control_tables.py
+++ b/backend/alembic/versions/20260619_0004_create_mission_control_tables.py
@@ -1,0 +1,101 @@
+"""create mission control tables
+
+Revision ID: 20260619_0004
+Revises: 20260615_0003
+Create Date: 2026-06-19
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260619_0004"
+down_revision: str | None = "20260615_0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "annotated_points",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=160), nullable=False),
+        sa.Column("type", sa.String(length=32), nullable=False),
+        sa.Column("x", sa.Float(), nullable=False),
+        sa.Column("y", sa.Float(), nullable=False),
+        sa.Column("yaw", sa.Float(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_annotated_points_is_active"), "annotated_points", ["is_active"], unique=False)
+    op.create_index(op.f("ix_annotated_points_type"), "annotated_points", ["type"], unique=False)
+
+    op.create_table(
+        "stock_point_supplies",
+        sa.Column("stock_point_id", sa.String(length=64), nullable=False),
+        sa.Column("supply_type", sa.String(length=64), nullable=False),
+        sa.Column("priority_order", sa.Integer(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(["stock_point_id"], ["annotated_points.id"]),
+        sa.PrimaryKeyConstraint("stock_point_id", "supply_type"),
+    )
+    op.create_index(op.f("ix_stock_point_supplies_is_active"), "stock_point_supplies", ["is_active"], unique=False)
+
+    op.create_table(
+        "missions",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=64), nullable=False),
+        sa.Column("supply_type", sa.String(length=64), nullable=False),
+        sa.Column("delivery_room_id", sa.String(length=64), nullable=False),
+        sa.Column("delivery_room_name_snapshot", sa.String(length=160), nullable=False),
+        sa.Column("delivery_x_snapshot", sa.Float(), nullable=False),
+        sa.Column("delivery_y_snapshot", sa.Float(), nullable=False),
+        sa.Column("delivery_yaw_snapshot", sa.Float(), nullable=False),
+        sa.Column("stock_point_id", sa.String(length=64), nullable=False),
+        sa.Column("stock_point_name_snapshot", sa.String(length=160), nullable=False),
+        sa.Column("stock_x_snapshot", sa.Float(), nullable=False),
+        sa.Column("stock_y_snapshot", sa.Float(), nullable=False),
+        sa.Column("stock_yaw_snapshot", sa.Float(), nullable=False),
+        sa.Column("created_by_user_id", sa.String(length=64), nullable=False),
+        sa.Column("created_by_name_snapshot", sa.String(length=160), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("arrived_at_stock_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("recovery_confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("recovery_confirmed_by_user_id", sa.String(length=64), nullable=True),
+        sa.Column("arrived_at_delivery_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("delivery_confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("delivery_confirmed_by_user_id", sa.String(length=64), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_by_user_id", sa.String(length=64), nullable=True),
+        sa.Column("failure_reason", sa.String(length=300), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_missions_created_at"), "missions", ["created_at"], unique=False)
+    op.create_index(op.f("ix_missions_created_by_user_id"), "missions", ["created_by_user_id"], unique=False)
+    op.create_index(op.f("ix_missions_delivery_room_id"), "missions", ["delivery_room_id"], unique=False)
+    op.create_index(op.f("ix_missions_status"), "missions", ["status"], unique=False)
+    op.create_index(op.f("ix_missions_stock_point_id"), "missions", ["stock_point_id"], unique=False)
+    op.create_index(op.f("ix_missions_supply_type"), "missions", ["supply_type"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_missions_supply_type"), table_name="missions")
+    op.drop_index(op.f("ix_missions_stock_point_id"), table_name="missions")
+    op.drop_index(op.f("ix_missions_status"), table_name="missions")
+    op.drop_index(op.f("ix_missions_delivery_room_id"), table_name="missions")
+    op.drop_index(op.f("ix_missions_created_by_user_id"), table_name="missions")
+    op.drop_index(op.f("ix_missions_created_at"), table_name="missions")
+    op.drop_table("missions")
+    op.drop_index(op.f("ix_stock_point_supplies_is_active"), table_name="stock_point_supplies")
+    op.drop_table("stock_point_supplies")
+    op.drop_index(op.f("ix_annotated_points_type"), table_name="annotated_points")
+    op.drop_index(op.f("ix_annotated_points_is_active"), table_name="annotated_points")
+    op.drop_table("annotated_points")

--- a/backend/app/application/dto/mission_dto.py
+++ b/backend/app/application/dto/mission_dto.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.domain.entities import mission as domain
+
+SupplyType = domain.SupplyType
+AnnotatedPointType = domain.AnnotatedPointType
+MissionStatus = domain.MissionStatus
+
+
+class DomainDto(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnnotatedPointCreateRequest(DomainDto):
+    name: str = Field(min_length=1, max_length=160)
+    type: domain.AnnotatedPointType
+    x: float
+    y: float
+    yaw: float = 0.0
+    is_active: bool = True
+
+
+class AnnotatedPointUpdateRequest(DomainDto):
+    name: str | None = Field(default=None, min_length=1, max_length=160)
+    type: domain.AnnotatedPointType | None = None
+    x: float | None = None
+    y: float | None = None
+    yaw: float | None = None
+    is_active: bool | None = None
+
+
+class AnnotatedPointResponse(DomainDto):
+    id: str
+    name: str
+    type: domain.AnnotatedPointType
+    x: float
+    y: float
+    yaw: float
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_domain(cls, point: domain.AnnotatedPoint) -> Self:
+        return cls.model_validate(asdict(point))
+
+
+class StockPointSupplyRequest(DomainDto):
+    supply_type: domain.SupplyType
+    priority_order: int = Field(default=1, ge=1)
+    is_active: bool = True
+
+
+class StockPointSuppliesUpdateRequest(DomainDto):
+    supplies: list[StockPointSupplyRequest] = Field(default_factory=list)
+
+
+class StockPointSupplyResponse(DomainDto):
+    stock_point_id: str
+    supply_type: domain.SupplyType
+    priority_order: int
+    is_active: bool
+
+    @classmethod
+    def from_domain(cls, supply: domain.StockPointSupply) -> Self:
+        return cls.model_validate(asdict(supply))
+
+
+class MissionCreateRequest(DomainDto):
+    supply_type: domain.SupplyType
+    delivery_room_id: str = Field(min_length=1, max_length=64)
+
+
+class MissionResponse(DomainDto):
+    id: str
+    status: domain.MissionStatus
+    supply_type: domain.SupplyType
+    delivery_room_id: str
+    delivery_room_name_snapshot: str
+    delivery_x_snapshot: float
+    delivery_y_snapshot: float
+    delivery_yaw_snapshot: float
+    stock_point_id: str
+    stock_point_name_snapshot: str
+    stock_x_snapshot: float
+    stock_y_snapshot: float
+    stock_yaw_snapshot: float
+    created_by_user_id: str
+    created_by_name_snapshot: str
+    created_at: datetime
+    started_at: datetime | None = None
+    arrived_at_stock_at: datetime | None = None
+    recovery_confirmed_at: datetime | None = None
+    recovery_confirmed_by_user_id: str | None = None
+    arrived_at_delivery_at: datetime | None = None
+    delivery_confirmed_at: datetime | None = None
+    delivery_confirmed_by_user_id: str | None = None
+    completed_at: datetime | None = None
+    cancelled_at: datetime | None = None
+    cancelled_by_user_id: str | None = None
+    failure_reason: str | None = None
+    updated_at: datetime
+
+    @classmethod
+    def from_domain(cls, mission: domain.Mission) -> Self:
+        return cls.model_validate(asdict(mission))
+
+
+class RobotScreenMission(DomainDto):
+    id: str
+    status: domain.MissionStatus
+    supply_label_fr: str
+    destination_label_fr: str
+
+
+class RobotScreenStatusResponse(DomainDto):
+    robot_state: str
+    screen_title_fr: str
+    screen_message_fr: str
+    current_mission: RobotScreenMission | None = None
+    updated_at: datetime

--- a/backend/app/application/use_cases/clear_emergency.py
+++ b/backend/app/application/use_cases/clear_emergency.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
+from app.application.use_cases.mission_orchestrator import MissionOrchestrator
 from app.domain.entities.mqtt_topics import ROBOT_ADMIN_TOPIC, ROBOT_EMERGENCY_TOPIC
 from app.domain.repositories.message_publisher import MessagePublisher
 from app.domain.repositories.robot_state_repository import RobotStateRepository
 
 
 class ClearEmergencyUseCase:
-    def __init__(self, state_repository: RobotStateRepository, message_publisher: MessagePublisher) -> None:
+    def __init__(
+        self,
+        state_repository: RobotStateRepository,
+        message_publisher: MessagePublisher,
+        mission_orchestrator: MissionOrchestrator | None = None,
+    ) -> None:
         self._state_repository = state_repository
         self._message_publisher = message_publisher
+        self._mission_orchestrator = mission_orchestrator
 
     def execute(self, actor: str) -> dict[str, str]:
         self._state_repository.clear_emergency()
+        if self._mission_orchestrator is not None:
+            self._mission_orchestrator.try_start_next_mission()
         self._message_publisher.publish_json(
             ROBOT_ADMIN_TOPIC,
             {

--- a/backend/app/application/use_cases/container.py
+++ b/backend/app/application/use_cases/container.py
@@ -10,6 +10,7 @@ from app.application.use_cases.get_authenticated_user import GetAuthenticatedUse
 from app.application.use_cases.get_robot_status import GetRobotStatusUseCase
 from app.application.use_cases.get_settings import GetSettingsUseCase
 from app.application.use_cases.list_users import ListUsersUseCase
+from app.application.use_cases.mission_orchestrator import MissionOrchestrator
 from app.application.use_cases.process_battery_telemetry import ProcessBatteryTelemetryUseCase
 from app.application.use_cases.process_emergency_telemetry import ProcessEmergencyTelemetryUseCase
 from app.application.use_cases.process_navigation_eta import ProcessNavigationEtaUseCase
@@ -19,6 +20,8 @@ from app.application.use_cases.send_robot_command import SendRobotCommandUseCase
 from app.application.use_cases.trigger_emergency_stop import TriggerEmergencyStopUseCase
 from app.application.use_cases.update_settings import UpdateSettingsUseCase
 from app.application.use_cases.update_user import UpdateUserUseCase
+from app.domain.repositories.annotated_point_repository import AnnotatedPointRepository
+from app.domain.repositories.mission_repository import MissionRepository
 
 
 @dataclass(frozen=True)
@@ -40,3 +43,6 @@ class ApplicationUseCases:
     get_settings: GetSettingsUseCase
     update_settings: UpdateSettingsUseCase
     send_robot_command: SendRobotCommandUseCase
+    annotated_points: AnnotatedPointRepository
+    missions: MissionRepository
+    mission_orchestrator: MissionOrchestrator

--- a/backend/app/application/use_cases/handle_mqtt_message.py
+++ b/backend/app/application/use_cases/handle_mqtt_message.py
@@ -19,6 +19,7 @@ from app.domain.entities.mqtt_topics import (
     ROBOT_EMERGENCY_TOPIC,
     ROBOT_NAV2_FEEDBACK_TOPIC,
     ROBOT_NAV2_PATH_TOPIC,
+    ROBOT_POSE_TOPIC,
     ROBOT_STATUS_TOPIC,
 )
 
@@ -49,6 +50,10 @@ class HandleMqttMessageUseCase:
 
         if topic == ROBOT_STATUS_TOPIC:
             self._handle_robot_status_payload(payload)
+            return
+
+        if topic == ROBOT_POSE_TOPIC:
+            self._handle_robot_status_payload(payload if "pose" in payload else {"pose": payload})
             return
 
         if topic == ROBOT_EMERGENCY_TOPIC:

--- a/backend/app/application/use_cases/mission_orchestrator.py
+++ b/backend/app/application/use_cases/mission_orchestrator.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+from uuid import uuid4
+
+from app.domain.entities.mission import (
+    CANCELLABLE_MISSION_STATUSES,
+    NAVIGATING_MISSION_STATUSES,
+    AnnotatedPointType,
+    Mission,
+    MissionStatus,
+    SupplyType,
+    utc_now,
+)
+from app.domain.entities.mqtt_topics import ROBOT_CMD_VEL_TOPIC, ROBOT_NAV_CANCEL_TOPIC
+from app.domain.entities.robot import RobotMode, RobotPose
+from app.domain.entities.robot_command import RobotCommand, RobotCommandType
+from app.domain.entities.user import User, UserRole
+from app.domain.repositories.annotated_point_repository import AnnotatedPointRepository
+from app.domain.repositories.message_publisher import MessagePublisher
+from app.domain.repositories.mission_repository import MissionRepository
+from app.domain.repositories.robot_command_publisher import RobotCommandPublisher
+from app.domain.repositories.robot_state_repository import RobotStateRepository
+from app.domain.repositories.settings_repository import SettingsRepository
+
+
+class MissionError(Exception):
+    pass
+
+
+class MissionNotFoundError(MissionError):
+    pass
+
+
+class MissionValidationError(MissionError):
+    pass
+
+
+class MissionTransitionError(MissionError):
+    pass
+
+
+class MissionOrchestrator:
+    def __init__(
+        self,
+        annotated_points: AnnotatedPointRepository,
+        missions: MissionRepository,
+        command_publisher: RobotCommandPublisher,
+        message_publisher: MessagePublisher,
+        state_repository: RobotStateRepository,
+        settings_repository: SettingsRepository,
+        arrival_radius_m: float,
+    ) -> None:
+        self._annotated_points = annotated_points
+        self._missions = missions
+        self._command_publisher = command_publisher
+        self._message_publisher = message_publisher
+        self._state_repository = state_repository
+        self._settings_repository = settings_repository
+        self._arrival_radius_m = arrival_radius_m
+
+    def create_mission(self, supply_type: SupplyType, delivery_room_id: str, actor: User) -> Mission:
+        delivery_room = self._annotated_points.get_point(delivery_room_id)
+        if (
+            delivery_room is None
+            or delivery_room.type != AnnotatedPointType.delivery_room
+            or not delivery_room.is_active
+        ):
+            raise MissionValidationError("Delivery room must be an active annotated delivery point")
+
+        stock_point = self._annotated_points.get_active_stock_for_supply(supply_type)
+        if stock_point is None:
+            raise MissionValidationError(f"No active stock can provide {supply_type.value}")
+
+        now = utc_now()
+        mission = Mission(
+            id=f"mis-{uuid4()}",
+            status=MissionStatus.pending,
+            supply_type=supply_type,
+            delivery_room_id=delivery_room.id,
+            delivery_room_name_snapshot=delivery_room.name,
+            delivery_x_snapshot=delivery_room.x,
+            delivery_y_snapshot=delivery_room.y,
+            delivery_yaw_snapshot=delivery_room.yaw,
+            stock_point_id=stock_point.id,
+            stock_point_name_snapshot=stock_point.name,
+            stock_x_snapshot=stock_point.x,
+            stock_y_snapshot=stock_point.y,
+            stock_yaw_snapshot=stock_point.yaw,
+            created_by_user_id=actor.id,
+            created_by_name_snapshot=actor.name,
+            created_at=now,
+            updated_at=now,
+        )
+        saved = self._missions.create_mission(mission)
+        self.try_start_next_mission()
+        return self._missions.get_mission(saved.id) or saved
+
+    def try_start_next_mission(self) -> Mission | None:
+        status = self._state_repository.get_status()
+        if status.emergency_active:
+            return None
+        if self._missions.get_active_mission() is not None:
+            return None
+
+        mission = self._missions.get_oldest_pending_mission()
+        if mission is None:
+            return None
+
+        started = replace(
+            mission,
+            status=MissionStatus.navigating_to_stock,
+            started_at=mission.started_at or utc_now(),
+        )
+        saved = self._missions.update_mission(started)
+        self._publish_navigation(saved, target="stock")
+        self._state_repository.set_mode(RobotMode.navigating, mission_id=saved.id)
+        return saved
+
+    def handle_robot_pose_updated(self, pose: RobotPose) -> Mission | None:
+        mission = self._missions.get_active_mission()
+        if mission is None:
+            return None
+        if mission.status == MissionStatus.navigating_to_stock:
+            if self._distance(pose.x, pose.y, mission.stock_x_snapshot, mission.stock_y_snapshot) <= self._arrival_radius_m:
+                arrived = self._missions.update_mission(
+                    replace(
+                        mission,
+                        status=MissionStatus.waiting_for_recovery_confirmation,
+                        arrived_at_stock_at=utc_now(),
+                    )
+                )
+                self._state_repository.set_mode(RobotMode.idle, mission_id=arrived.id)
+                return arrived
+        elif mission.status == MissionStatus.navigating_to_delivery:
+            if self._distance(pose.x, pose.y, mission.delivery_x_snapshot, mission.delivery_y_snapshot) <= self._arrival_radius_m:
+                arrived = self._missions.update_mission(
+                    replace(
+                        mission,
+                        status=MissionStatus.waiting_for_delivery_confirmation,
+                        arrived_at_delivery_at=utc_now(),
+                    )
+                )
+                self._state_repository.set_mode(RobotMode.idle, mission_id=arrived.id)
+                return arrived
+        return None
+
+    def confirm_recovery(self, mission_id: str, actor: User) -> Mission:
+        mission = self._get_mission_or_raise(mission_id)
+        if mission.status != MissionStatus.waiting_for_recovery_confirmation:
+            raise MissionTransitionError("Mission is not waiting for recovery confirmation")
+
+        confirmed = self._missions.update_mission(
+            replace(
+                mission,
+                status=MissionStatus.navigating_to_delivery,
+                recovery_confirmed_at=utc_now(),
+                recovery_confirmed_by_user_id=actor.id,
+            )
+        )
+        self._publish_navigation(confirmed, target="delivery")
+        self._state_repository.set_mode(RobotMode.navigating, mission_id=confirmed.id)
+        return confirmed
+
+    def confirm_delivery(self, mission_id: str, actor: User) -> Mission:
+        mission = self._get_mission_or_raise(mission_id)
+        if mission.status != MissionStatus.waiting_for_delivery_confirmation:
+            raise MissionTransitionError("Mission is not waiting for delivery confirmation")
+
+        completed = self._missions.update_mission(
+            replace(
+                mission,
+                status=MissionStatus.completed,
+                delivery_confirmed_at=utc_now(),
+                delivery_confirmed_by_user_id=actor.id,
+                completed_at=utc_now(),
+            )
+        )
+        self._state_repository.set_mode(RobotMode.idle, mission_id=None)
+        self.try_start_next_mission()
+        return completed
+
+    def cancel_mission(self, mission_id: str, actor: User) -> Mission:
+        mission = self._get_mission_or_raise(mission_id)
+        if mission.status not in CANCELLABLE_MISSION_STATUSES:
+            raise MissionTransitionError("Mission cannot be cancelled in its current state")
+
+        if mission.status in NAVIGATING_MISSION_STATUSES:
+            self._cancel_robot_navigation(mission.id)
+
+        cancelled = self._missions.update_mission(
+            replace(
+                mission,
+                status=MissionStatus.cancelled,
+                cancelled_at=utc_now(),
+                cancelled_by_user_id=actor.id,
+            )
+        )
+        active = self._missions.get_active_mission()
+        if active is None:
+            self._state_repository.set_mode(RobotMode.idle, mission_id=None)
+            self.try_start_next_mission()
+        return cancelled
+
+    def fail_active_mission(self, reason: str) -> Mission | None:
+        mission = self._missions.get_active_mission()
+        if mission is None or mission.status not in NAVIGATING_MISSION_STATUSES:
+            return None
+        self._cancel_robot_navigation(mission.id)
+        failed = self._missions.update_mission(
+            replace(
+                mission,
+                status=MissionStatus.failed,
+                failure_reason=reason,
+            )
+        )
+        self._state_repository.set_mode(RobotMode.emergency_stop, mission_id=None)
+        return failed
+
+    def _get_mission_or_raise(self, mission_id: str) -> Mission:
+        mission = self._missions.get_mission(mission_id)
+        if mission is None:
+            raise MissionNotFoundError("Mission not found")
+        return mission
+
+    def _publish_navigation(self, mission: Mission, target: str) -> None:
+        settings = self._settings_repository.get_settings()
+        if target == "stock":
+            x = mission.stock_x_snapshot
+            y = mission.stock_y_snapshot
+            yaw = mission.stock_yaw_snapshot
+            label = mission.stock_point_name_snapshot
+        else:
+            x = mission.delivery_x_snapshot
+            y = mission.delivery_y_snapshot
+            yaw = mission.delivery_yaw_snapshot
+            label = mission.delivery_room_name_snapshot
+
+        command = RobotCommand(
+            command_id=f"cmd-{uuid4()}",
+            type=RobotCommandType.navigate,
+            requested_by="mission-orchestrator",
+            requested_by_role=UserRole.admin,
+            payload={
+                "x": x,
+                "y": y,
+                "yaw": yaw,
+                "label": label,
+                "mission_id": mission.id,
+                "mission_target": target,
+                "max_speed_mps": settings.max_speed_mps,
+            },
+            timestamp=utc_now(),
+        )
+        self._command_publisher.publish(command)
+
+    def _cancel_robot_navigation(self, mission_id: str) -> None:
+        self._message_publisher.publish_json(ROBOT_NAV_CANCEL_TOPIC, {"mission_id": mission_id, "reason": "mission_cancelled"}, qos=1)
+        self._message_publisher.publish_json(ROBOT_CMD_VEL_TOPIC, {"linear_x": 0, "angular_z": 0, "mission_id": mission_id}, qos=1)
+
+    @staticmethod
+    def _distance(x1: float, y1: float, x2: float, y2: float) -> float:
+        return math.hypot(x1 - x2, y1 - y2)

--- a/backend/app/application/use_cases/process_emergency_telemetry.py
+++ b/backend/app/application/use_cases/process_emergency_telemetry.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from app.application.use_cases.mission_orchestrator import MissionOrchestrator
 from app.domain.entities.robot import EmergencyEvent, EmergencyStopRequest, RobotStatus
 from app.domain.repositories.robot_state_repository import RobotStateRepository
 
 
 class ProcessEmergencyTelemetryUseCase:
-    def __init__(self, state_repository: RobotStateRepository) -> None:
+    def __init__(self, state_repository: RobotStateRepository, mission_orchestrator: MissionOrchestrator | None = None) -> None:
         self._state_repository = state_repository
+        self._mission_orchestrator = mission_orchestrator
 
     def execute(self, request: EmergencyStopRequest) -> EmergencyEvent:
         event = EmergencyEvent(
@@ -15,7 +17,12 @@ class ProcessEmergencyTelemetryUseCase:
             requires_admin_restart=request.requires_admin_restart,
         )
         self._state_repository.trigger_emergency(event)
+        if self._mission_orchestrator is not None:
+            self._mission_orchestrator.fail_active_mission("emergency_stop")
         return event
 
     def clear(self) -> RobotStatus:
-        return self._state_repository.clear_emergency()
+        status = self._state_repository.clear_emergency()
+        if self._mission_orchestrator is not None:
+            self._mission_orchestrator.try_start_next_mission()
+        return status

--- a/backend/app/application/use_cases/process_robot_status_telemetry.py
+++ b/backend/app/application/use_cases/process_robot_status_telemetry.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+from app.application.use_cases.mission_orchestrator import MissionOrchestrator
 from app.domain.entities.robot import RobotRuntimeTelemetry, RobotStatus
 from app.domain.repositories.robot_state_repository import RobotStateRepository
 
 
 class ProcessRobotStatusTelemetryUseCase:
-    def __init__(self, state_repository: RobotStateRepository) -> None:
+    def __init__(self, state_repository: RobotStateRepository, mission_orchestrator: MissionOrchestrator | None = None) -> None:
         self._state_repository = state_repository
+        self._mission_orchestrator = mission_orchestrator
 
     def execute(self, telemetry: RobotRuntimeTelemetry) -> RobotStatus:
-        return self._state_repository.update_runtime(telemetry)
+        status = self._state_repository.update_runtime(telemetry)
+        if self._mission_orchestrator is None:
+            return status
+
+        if telemetry.emergency_active:
+            self._mission_orchestrator.fail_active_mission("emergency_stop")
+        elif telemetry.pose is not None:
+            self._mission_orchestrator.handle_robot_pose_updated(telemetry.pose)
+        return status

--- a/backend/app/application/use_cases/trigger_emergency_stop.py
+++ b/backend/app/application/use_cases/trigger_emergency_stop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.application.use_cases.mission_orchestrator import MissionOrchestrator
 from app.domain.entities.mqtt_topics import ROBOT_COMMAND_TOPIC, ROBOT_EMERGENCY_TOPIC, ROBOT_UI_ALERTS_TOPIC
 from app.domain.entities.robot import EmergencyEvent, EmergencyStopRequest, Severity
 from app.domain.repositories.message_publisher import MessagePublisher
@@ -7,9 +8,15 @@ from app.domain.repositories.robot_state_repository import RobotStateRepository
 
 
 class TriggerEmergencyStopUseCase:
-    def __init__(self, state_repository: RobotStateRepository, message_publisher: MessagePublisher) -> None:
+    def __init__(
+        self,
+        state_repository: RobotStateRepository,
+        message_publisher: MessagePublisher,
+        mission_orchestrator: MissionOrchestrator | None = None,
+    ) -> None:
         self._state_repository = state_repository
         self._message_publisher = message_publisher
+        self._mission_orchestrator = mission_orchestrator
 
     def execute(self, request: EmergencyStopRequest) -> EmergencyEvent:
         event = EmergencyEvent(
@@ -18,6 +25,8 @@ class TriggerEmergencyStopUseCase:
             requires_admin_restart=request.requires_admin_restart,
         )
         self._state_repository.trigger_emergency(event)
+        if self._mission_orchestrator is not None:
+            self._mission_orchestrator.fail_active_mission("emergency_stop")
         self._message_publisher.publish_json(
             ROBOT_COMMAND_TOPIC,
             {

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -71,6 +71,9 @@ class Settings:
         "SETTINGS_REPOSITORY_BACKEND",
         os.getenv("USER_REPOSITORY_BACKEND", "memory"),
     )
+    mission_repository_backend: str = os.getenv("MISSION_REPOSITORY_BACKEND", "database")
+    mission_arrival_radius_m: float = float(os.getenv("MISSION_ARRIVAL_RADIUS_M", "0.60"))
+    robot_screen_token: Optional[str] = os.getenv("ROBOT_SCREEN_TOKEN")
 
 
 settings = Settings()

--- a/backend/app/domain/entities/mission.py
+++ b/backend/app/domain/entities/mission.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class SupplyType(str, Enum):
+    serviettes = "serviettes"
+    papier_toilette = "papier_toilette"
+    gants = "gants"
+    protections = "protections"
+    linge = "linge"
+
+
+class AnnotatedPointType(str, Enum):
+    stock = "STOCK"
+    delivery_room = "DELIVERY_ROOM"
+    robot_base = "ROBOT_BASE"
+
+
+class MissionStatus(str, Enum):
+    pending = "PENDING"
+    navigating_to_stock = "NAVIGATING_TO_STOCK"
+    waiting_for_recovery_confirmation = "WAITING_FOR_RECOVERY_CONFIRMATION"
+    navigating_to_delivery = "NAVIGATING_TO_DELIVERY"
+    waiting_for_delivery_confirmation = "WAITING_FOR_DELIVERY_CONFIRMATION"
+    completed = "COMPLETED"
+    cancelled = "CANCELLED"
+    failed = "FAILED"
+
+
+TERMINAL_MISSION_STATUSES = {
+    MissionStatus.completed,
+    MissionStatus.cancelled,
+    MissionStatus.failed,
+}
+ACTIVE_MISSION_STATUSES = {
+    MissionStatus.navigating_to_stock,
+    MissionStatus.waiting_for_recovery_confirmation,
+    MissionStatus.navigating_to_delivery,
+    MissionStatus.waiting_for_delivery_confirmation,
+}
+NAVIGATING_MISSION_STATUSES = {
+    MissionStatus.navigating_to_stock,
+    MissionStatus.navigating_to_delivery,
+}
+CANCELLABLE_MISSION_STATUSES = {MissionStatus.pending, *ACTIVE_MISSION_STATUSES}
+
+
+@dataclass(frozen=True)
+class AnnotatedPoint:
+    id: str
+    name: str
+    type: AnnotatedPointType
+    x: float
+    y: float
+    yaw: float
+    is_active: bool = True
+    created_at: datetime = field(default_factory=utc_now)
+    updated_at: datetime = field(default_factory=utc_now)
+
+
+@dataclass(frozen=True)
+class StockPointSupply:
+    stock_point_id: str
+    supply_type: SupplyType
+    priority_order: int
+    is_active: bool = True
+
+
+@dataclass(frozen=True)
+class Mission:
+    id: str
+    status: MissionStatus
+    supply_type: SupplyType
+    delivery_room_id: str
+    delivery_room_name_snapshot: str
+    delivery_x_snapshot: float
+    delivery_y_snapshot: float
+    delivery_yaw_snapshot: float
+    stock_point_id: str
+    stock_point_name_snapshot: str
+    stock_x_snapshot: float
+    stock_y_snapshot: float
+    stock_yaw_snapshot: float
+    created_by_user_id: str
+    created_by_name_snapshot: str
+    created_at: datetime = field(default_factory=utc_now)
+    started_at: datetime | None = None
+    arrived_at_stock_at: datetime | None = None
+    recovery_confirmed_at: datetime | None = None
+    recovery_confirmed_by_user_id: str | None = None
+    arrived_at_delivery_at: datetime | None = None
+    delivery_confirmed_at: datetime | None = None
+    delivery_confirmed_by_user_id: str | None = None
+    completed_at: datetime | None = None
+    cancelled_at: datetime | None = None
+    cancelled_by_user_id: str | None = None
+    failure_reason: str | None = None
+    updated_at: datetime = field(default_factory=utc_now)

--- a/backend/app/domain/repositories/annotated_point_repository.py
+++ b/backend/app/domain/repositories/annotated_point_repository.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.domain.entities.mission import AnnotatedPoint, AnnotatedPointType, StockPointSupply, SupplyType
+
+
+class AnnotatedPointRepository(Protocol):
+    def list_points(
+        self,
+        point_type: AnnotatedPointType | None = None,
+        active_only: bool = False,
+    ) -> list[AnnotatedPoint]: ...
+
+    def get_point(self, point_id: str) -> AnnotatedPoint | None: ...
+
+    def create_point(self, point: AnnotatedPoint) -> AnnotatedPoint: ...
+
+    def update_point(self, point: AnnotatedPoint) -> AnnotatedPoint: ...
+
+    def deactivate_point(self, point_id: str) -> AnnotatedPoint | None: ...
+
+    def replace_stock_supplies(
+        self,
+        stock_point_id: str,
+        supplies: list[StockPointSupply],
+    ) -> list[StockPointSupply]: ...
+
+    def list_stock_supplies(
+        self,
+        stock_point_id: str | None = None,
+        active_only: bool = True,
+    ) -> list[StockPointSupply]: ...
+
+    def get_active_stock_for_supply(self, supply_type: SupplyType) -> AnnotatedPoint | None: ...

--- a/backend/app/domain/repositories/mission_repository.py
+++ b/backend/app/domain/repositories/mission_repository.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.domain.entities.mission import Mission
+
+
+class MissionRepository(Protocol):
+    def create_mission(self, mission: Mission) -> Mission: ...
+
+    def update_mission(self, mission: Mission) -> Mission: ...
+
+    def get_mission(self, mission_id: str) -> Mission | None: ...
+
+    def list_missions(self, include_terminal: bool = False, limit: int = 100) -> list[Mission]: ...
+
+    def get_active_mission(self) -> Mission | None: ...
+
+    def get_oldest_pending_mission(self) -> Mission | None: ...

--- a/backend/app/infrastructure/database/models/__init__.py
+++ b/backend/app/infrastructure/database/models/__init__.py
@@ -1,4 +1,5 @@
+from app.infrastructure.database.models.mission_model import AnnotatedPointModel, MissionModel, StockPointSupplyModel
 from app.infrastructure.database.models.settings_model import RobotSettingsModel
 from app.infrastructure.database.models.user_model import UserModel
 
-__all__ = ["RobotSettingsModel", "UserModel"]
+__all__ = ["AnnotatedPointModel", "MissionModel", "RobotSettingsModel", "StockPointSupplyModel", "UserModel"]

--- a/backend/app/infrastructure/database/models/mission_model.py
+++ b/backend/app/infrastructure/database/models/mission_model.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.infrastructure.database.base import Base
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AnnotatedPointModel(Base):
+    __tablename__ = "annotated_points"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    name: Mapped[str] = mapped_column(String(160), nullable=False)
+    type: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    x: Mapped[float] = mapped_column(Float, nullable=False)
+    y: Mapped[float] = mapped_column(Float, nullable=False)
+    yaw: Mapped[float] = mapped_column(Float, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        onupdate=utc_now,
+    )
+
+
+class StockPointSupplyModel(Base):
+    __tablename__ = "stock_point_supplies"
+
+    stock_point_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("annotated_points.id"),
+        primary_key=True,
+    )
+    supply_type: Mapped[str] = mapped_column(String(64), primary_key=True)
+    priority_order: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, index=True)
+
+
+class MissionModel(Base):
+    __tablename__ = "missions"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    status: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    supply_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    delivery_room_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    delivery_room_name_snapshot: Mapped[str] = mapped_column(String(160), nullable=False)
+    delivery_x_snapshot: Mapped[float] = mapped_column(Float, nullable=False)
+    delivery_y_snapshot: Mapped[float] = mapped_column(Float, nullable=False)
+    delivery_yaw_snapshot: Mapped[float] = mapped_column(Float, nullable=False)
+    stock_point_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    stock_point_name_snapshot: Mapped[str] = mapped_column(String(160), nullable=False)
+    stock_x_snapshot: Mapped[float] = mapped_column(Float, nullable=False)
+    stock_y_snapshot: Mapped[float] = mapped_column(Float, nullable=False)
+    stock_yaw_snapshot: Mapped[float] = mapped_column(Float, nullable=False)
+    created_by_user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    created_by_name_snapshot: Mapped[str] = mapped_column(String(160), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=utc_now, index=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    arrived_at_stock_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    recovery_confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    recovery_confirmed_by_user_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    arrived_at_delivery_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    delivery_confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    delivery_confirmed_by_user_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cancelled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cancelled_by_user_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(String(300), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        onupdate=utc_now,
+    )

--- a/backend/app/infrastructure/repositories/in_memory_mission_repository.py
+++ b/backend/app/infrastructure/repositories/in_memory_mission_repository.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from threading import Lock
+
+from app.domain.entities.mission import (
+    ACTIVE_MISSION_STATUSES,
+    TERMINAL_MISSION_STATUSES,
+    AnnotatedPoint,
+    AnnotatedPointType,
+    Mission,
+    MissionStatus,
+    StockPointSupply,
+    SupplyType,
+    utc_now,
+)
+
+
+class InMemoryMissionRepository:
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._points: dict[str, AnnotatedPoint] = {}
+        self._supplies: dict[tuple[str, SupplyType], StockPointSupply] = {}
+        self._missions: dict[str, Mission] = {}
+
+    def list_points(
+        self,
+        point_type: AnnotatedPointType | None = None,
+        active_only: bool = False,
+    ) -> list[AnnotatedPoint]:
+        with self._lock:
+            points = list(self._points.values())
+            if point_type is not None:
+                points = [point for point in points if point.type == point_type]
+            if active_only:
+                points = [point for point in points if point.is_active]
+            points.sort(key=lambda point: (point.type.value, point.name.lower(), point.created_at))
+            return deepcopy(points)
+
+    def get_point(self, point_id: str) -> AnnotatedPoint | None:
+        with self._lock:
+            point = self._points.get(point_id)
+            return deepcopy(point) if point is not None else None
+
+    def create_point(self, point: AnnotatedPoint) -> AnnotatedPoint:
+        with self._lock:
+            self._points[point.id] = point
+            return deepcopy(point)
+
+    def update_point(self, point: AnnotatedPoint) -> AnnotatedPoint:
+        with self._lock:
+            updated = replace(point, updated_at=utc_now())
+            self._points[point.id] = updated
+            return deepcopy(updated)
+
+    def deactivate_point(self, point_id: str) -> AnnotatedPoint | None:
+        with self._lock:
+            point = self._points.get(point_id)
+            if point is None:
+                return None
+            deactivated = replace(point, is_active=False, updated_at=utc_now())
+            self._points[point_id] = deactivated
+            return deepcopy(deactivated)
+
+    def replace_stock_supplies(
+        self,
+        stock_point_id: str,
+        supplies: list[StockPointSupply],
+    ) -> list[StockPointSupply]:
+        with self._lock:
+            for key, existing in list(self._supplies.items()):
+                if key[0] == stock_point_id:
+                    self._supplies[key] = replace(existing, is_active=False)
+
+            for supply in supplies:
+                self._supplies[(stock_point_id, supply.supply_type)] = supply
+
+            active = [supply for supply in self._supplies.values() if supply.stock_point_id == stock_point_id and supply.is_active]
+            active.sort(key=lambda supply: (supply.priority_order, supply.supply_type.value))
+            return deepcopy(active)
+
+    def list_stock_supplies(
+        self,
+        stock_point_id: str | None = None,
+        active_only: bool = True,
+    ) -> list[StockPointSupply]:
+        with self._lock:
+            supplies = list(self._supplies.values())
+            if stock_point_id is not None:
+                supplies = [supply for supply in supplies if supply.stock_point_id == stock_point_id]
+            if active_only:
+                supplies = [supply for supply in supplies if supply.is_active]
+            supplies.sort(key=lambda supply: (supply.stock_point_id, supply.priority_order, supply.supply_type.value))
+            return deepcopy(supplies)
+
+    def get_active_stock_for_supply(self, supply_type: SupplyType) -> AnnotatedPoint | None:
+        with self._lock:
+            candidates: list[tuple[int, str, AnnotatedPoint]] = []
+            for supply in self._supplies.values():
+                if supply.supply_type != supply_type or not supply.is_active:
+                    continue
+                point = self._points.get(supply.stock_point_id)
+                if point is None or point.type != AnnotatedPointType.stock or not point.is_active:
+                    continue
+                candidates.append((supply.priority_order, point.name.lower(), point))
+            if not candidates:
+                return None
+            candidates.sort(key=lambda item: (item[0], item[1]))
+            return deepcopy(candidates[0][2])
+
+    def create_mission(self, mission: Mission) -> Mission:
+        with self._lock:
+            self._missions[mission.id] = mission
+            return deepcopy(mission)
+
+    def update_mission(self, mission: Mission) -> Mission:
+        with self._lock:
+            updated = replace(mission, updated_at=utc_now())
+            self._missions[mission.id] = updated
+            return deepcopy(updated)
+
+    def get_mission(self, mission_id: str) -> Mission | None:
+        with self._lock:
+            mission = self._missions.get(mission_id)
+            return deepcopy(mission) if mission is not None else None
+
+    def list_missions(self, include_terminal: bool = False, limit: int = 100) -> list[Mission]:
+        with self._lock:
+            missions = list(self._missions.values())
+            if not include_terminal:
+                missions = [mission for mission in missions if mission.status not in TERMINAL_MISSION_STATUSES]
+            missions.sort(key=lambda mission: mission.created_at)
+            return deepcopy(missions[:limit])
+
+    def get_active_mission(self) -> Mission | None:
+        with self._lock:
+            missions = [mission for mission in self._missions.values() if mission.status in ACTIVE_MISSION_STATUSES]
+            missions.sort(key=lambda mission: mission.created_at)
+            return deepcopy(missions[0]) if missions else None
+
+    def get_oldest_pending_mission(self) -> Mission | None:
+        with self._lock:
+            missions = [mission for mission in self._missions.values() if mission.status == MissionStatus.pending]
+            missions.sort(key=lambda mission: mission.created_at)
+            return deepcopy(missions[0]) if missions else None

--- a/backend/app/infrastructure/repositories/sqlalchemy_mission_repository.py
+++ b/backend/app/infrastructure/repositories/sqlalchemy_mission_repository.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.entities.mission import (
+    ACTIVE_MISSION_STATUSES,
+    TERMINAL_MISSION_STATUSES,
+    AnnotatedPoint,
+    AnnotatedPointType,
+    Mission,
+    MissionStatus,
+    StockPointSupply,
+    SupplyType,
+    utc_now,
+)
+from app.infrastructure.database.models.mission_model import AnnotatedPointModel, MissionModel, StockPointSupplyModel
+
+
+class SqlAlchemyMissionRepository:
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session_factory = session_factory
+
+    def list_points(
+        self,
+        point_type: AnnotatedPointType | None = None,
+        active_only: bool = False,
+    ) -> list[AnnotatedPoint]:
+        with self._session_factory() as session:
+            query = select(AnnotatedPointModel)
+            if point_type is not None:
+                query = query.where(AnnotatedPointModel.type == point_type.value)
+            if active_only:
+                query = query.where(AnnotatedPointModel.is_active.is_(True))
+            query = query.order_by(AnnotatedPointModel.type, AnnotatedPointModel.name, AnnotatedPointModel.created_at)
+            return [self._point_to_domain(model) for model in session.scalars(query).all()]
+
+    def get_point(self, point_id: str) -> AnnotatedPoint | None:
+        with self._session_factory() as session:
+            model = session.get(AnnotatedPointModel, point_id)
+            return self._point_to_domain(model) if model is not None else None
+
+    def create_point(self, point: AnnotatedPoint) -> AnnotatedPoint:
+        with self._session_factory() as session:
+            model = AnnotatedPointModel(
+                id=point.id,
+                name=point.name,
+                type=point.type.value,
+                x=point.x,
+                y=point.y,
+                yaw=point.yaw,
+                is_active=point.is_active,
+                created_at=point.created_at,
+                updated_at=point.updated_at,
+            )
+            session.add(model)
+            session.commit()
+            session.refresh(model)
+            return self._point_to_domain(model)
+
+    def update_point(self, point: AnnotatedPoint) -> AnnotatedPoint:
+        with self._session_factory() as session:
+            model = session.get(AnnotatedPointModel, point.id)
+            if model is None:
+                raise ValueError("Cannot update missing annotated point")
+            model.name = point.name
+            model.type = point.type.value
+            model.x = point.x
+            model.y = point.y
+            model.yaw = point.yaw
+            model.is_active = point.is_active
+            model.updated_at = utc_now()
+            session.commit()
+            session.refresh(model)
+            return self._point_to_domain(model)
+
+    def deactivate_point(self, point_id: str) -> AnnotatedPoint | None:
+        with self._session_factory() as session:
+            model = session.get(AnnotatedPointModel, point_id)
+            if model is None:
+                return None
+            model.is_active = False
+            model.updated_at = utc_now()
+            session.commit()
+            session.refresh(model)
+            return self._point_to_domain(model)
+
+    def replace_stock_supplies(
+        self,
+        stock_point_id: str,
+        supplies: list[StockPointSupply],
+    ) -> list[StockPointSupply]:
+        with self._session_factory() as session:
+            existing = session.scalars(
+                select(StockPointSupplyModel).where(StockPointSupplyModel.stock_point_id == stock_point_id)
+            ).all()
+            existing_by_supply = {SupplyType(model.supply_type): model for model in existing}
+
+            for model in existing:
+                model.is_active = False
+
+            for supply in supplies:
+                model = existing_by_supply.get(supply.supply_type)
+                if model is None:
+                    model = StockPointSupplyModel(
+                        stock_point_id=stock_point_id,
+                        supply_type=supply.supply_type.value,
+                        priority_order=supply.priority_order,
+                        is_active=supply.is_active,
+                    )
+                    session.add(model)
+                else:
+                    model.priority_order = supply.priority_order
+                    model.is_active = supply.is_active
+
+            session.commit()
+            return self.list_stock_supplies(stock_point_id=stock_point_id, active_only=True)
+
+    def list_stock_supplies(
+        self,
+        stock_point_id: str | None = None,
+        active_only: bool = True,
+    ) -> list[StockPointSupply]:
+        with self._session_factory() as session:
+            query = select(StockPointSupplyModel)
+            if stock_point_id is not None:
+                query = query.where(StockPointSupplyModel.stock_point_id == stock_point_id)
+            if active_only:
+                query = query.where(StockPointSupplyModel.is_active.is_(True))
+            query = query.order_by(
+                StockPointSupplyModel.stock_point_id,
+                StockPointSupplyModel.priority_order,
+                StockPointSupplyModel.supply_type,
+            )
+            return [self._supply_to_domain(model) for model in session.scalars(query).all()]
+
+    def get_active_stock_for_supply(self, supply_type: SupplyType) -> AnnotatedPoint | None:
+        with self._session_factory() as session:
+            query = (
+                select(AnnotatedPointModel)
+                .join(StockPointSupplyModel, StockPointSupplyModel.stock_point_id == AnnotatedPointModel.id)
+                .where(
+                    AnnotatedPointModel.type == AnnotatedPointType.stock.value,
+                    AnnotatedPointModel.is_active.is_(True),
+                    StockPointSupplyModel.supply_type == supply_type.value,
+                    StockPointSupplyModel.is_active.is_(True),
+                )
+                .order_by(StockPointSupplyModel.priority_order, AnnotatedPointModel.name, AnnotatedPointModel.created_at)
+                .limit(1)
+            )
+            model = session.scalars(query).one_or_none()
+            return self._point_to_domain(model) if model is not None else None
+
+    def create_mission(self, mission: Mission) -> Mission:
+        with self._session_factory() as session:
+            model = self._mission_to_model(mission)
+            session.add(model)
+            session.commit()
+            session.refresh(model)
+            return self._mission_to_domain(model)
+
+    def update_mission(self, mission: Mission) -> Mission:
+        with self._session_factory() as session:
+            model = session.get(MissionModel, mission.id)
+            if model is None:
+                raise ValueError("Cannot update missing mission")
+            updated = replace(mission, updated_at=utc_now())
+            self._copy_mission_to_model(updated, model)
+            session.commit()
+            session.refresh(model)
+            return self._mission_to_domain(model)
+
+    def get_mission(self, mission_id: str) -> Mission | None:
+        with self._session_factory() as session:
+            model = session.get(MissionModel, mission_id)
+            return self._mission_to_domain(model) if model is not None else None
+
+    def list_missions(self, include_terminal: bool = False, limit: int = 100) -> list[Mission]:
+        with self._session_factory() as session:
+            query = select(MissionModel)
+            if not include_terminal:
+                query = query.where(MissionModel.status.not_in([status.value for status in TERMINAL_MISSION_STATUSES]))
+            query = query.order_by(MissionModel.created_at).limit(limit)
+            return [self._mission_to_domain(model) for model in session.scalars(query).all()]
+
+    def get_active_mission(self) -> Mission | None:
+        with self._session_factory() as session:
+            query = (
+                select(MissionModel)
+                .where(MissionModel.status.in_([status.value for status in ACTIVE_MISSION_STATUSES]))
+                .order_by(MissionModel.created_at)
+                .limit(1)
+            )
+            model = session.scalars(query).one_or_none()
+            return self._mission_to_domain(model) if model is not None else None
+
+    def get_oldest_pending_mission(self) -> Mission | None:
+        with self._session_factory() as session:
+            query = (
+                select(MissionModel)
+                .where(MissionModel.status == MissionStatus.pending.value)
+                .order_by(MissionModel.created_at)
+                .limit(1)
+            )
+            model = session.scalars(query).one_or_none()
+            return self._mission_to_domain(model) if model is not None else None
+
+    @staticmethod
+    def _point_to_domain(model: AnnotatedPointModel) -> AnnotatedPoint:
+        return AnnotatedPoint(
+            id=model.id,
+            name=model.name,
+            type=AnnotatedPointType(model.type),
+            x=model.x,
+            y=model.y,
+            yaw=model.yaw,
+            is_active=model.is_active,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    @staticmethod
+    def _supply_to_domain(model: StockPointSupplyModel) -> StockPointSupply:
+        return StockPointSupply(
+            stock_point_id=model.stock_point_id,
+            supply_type=SupplyType(model.supply_type),
+            priority_order=model.priority_order,
+            is_active=model.is_active,
+        )
+
+    @staticmethod
+    def _mission_to_model(mission: Mission) -> MissionModel:
+        model = MissionModel()
+        SqlAlchemyMissionRepository._copy_mission_to_model(mission, model)
+        return model
+
+    @staticmethod
+    def _copy_mission_to_model(mission: Mission, model: MissionModel) -> None:
+        model.id = mission.id
+        model.status = mission.status.value
+        model.supply_type = mission.supply_type.value
+        model.delivery_room_id = mission.delivery_room_id
+        model.delivery_room_name_snapshot = mission.delivery_room_name_snapshot
+        model.delivery_x_snapshot = mission.delivery_x_snapshot
+        model.delivery_y_snapshot = mission.delivery_y_snapshot
+        model.delivery_yaw_snapshot = mission.delivery_yaw_snapshot
+        model.stock_point_id = mission.stock_point_id
+        model.stock_point_name_snapshot = mission.stock_point_name_snapshot
+        model.stock_x_snapshot = mission.stock_x_snapshot
+        model.stock_y_snapshot = mission.stock_y_snapshot
+        model.stock_yaw_snapshot = mission.stock_yaw_snapshot
+        model.created_by_user_id = mission.created_by_user_id
+        model.created_by_name_snapshot = mission.created_by_name_snapshot
+        model.created_at = mission.created_at
+        model.started_at = mission.started_at
+        model.arrived_at_stock_at = mission.arrived_at_stock_at
+        model.recovery_confirmed_at = mission.recovery_confirmed_at
+        model.recovery_confirmed_by_user_id = mission.recovery_confirmed_by_user_id
+        model.arrived_at_delivery_at = mission.arrived_at_delivery_at
+        model.delivery_confirmed_at = mission.delivery_confirmed_at
+        model.delivery_confirmed_by_user_id = mission.delivery_confirmed_by_user_id
+        model.completed_at = mission.completed_at
+        model.cancelled_at = mission.cancelled_at
+        model.cancelled_by_user_id = mission.cancelled_by_user_id
+        model.failure_reason = mission.failure_reason
+        model.updated_at = mission.updated_at
+
+    @staticmethod
+    def _mission_to_domain(model: MissionModel) -> Mission:
+        return Mission(
+            id=model.id,
+            status=MissionStatus(model.status),
+            supply_type=SupplyType(model.supply_type),
+            delivery_room_id=model.delivery_room_id,
+            delivery_room_name_snapshot=model.delivery_room_name_snapshot,
+            delivery_x_snapshot=model.delivery_x_snapshot,
+            delivery_y_snapshot=model.delivery_y_snapshot,
+            delivery_yaw_snapshot=model.delivery_yaw_snapshot,
+            stock_point_id=model.stock_point_id,
+            stock_point_name_snapshot=model.stock_point_name_snapshot,
+            stock_x_snapshot=model.stock_x_snapshot,
+            stock_y_snapshot=model.stock_y_snapshot,
+            stock_yaw_snapshot=model.stock_yaw_snapshot,
+            created_by_user_id=model.created_by_user_id,
+            created_by_name_snapshot=model.created_by_name_snapshot,
+            created_at=model.created_at,
+            started_at=model.started_at,
+            arrived_at_stock_at=model.arrived_at_stock_at,
+            recovery_confirmed_at=model.recovery_confirmed_at,
+            recovery_confirmed_by_user_id=model.recovery_confirmed_by_user_id,
+            arrived_at_delivery_at=model.arrived_at_delivery_at,
+            delivery_confirmed_at=model.delivery_confirmed_at,
+            delivery_confirmed_by_user_id=model.delivery_confirmed_by_user_id,
+            completed_at=model.completed_at,
+            cancelled_at=model.cancelled_at,
+            cancelled_by_user_id=model.cancelled_by_user_id,
+            failure_reason=model.failure_reason,
+            updated_at=model.updated_at,
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.application.use_cases.get_robot_status import GetRobotStatusUseCase
 from app.application.use_cases.get_settings import GetSettingsUseCase
 from app.application.use_cases.handle_mqtt_message import HandleMqttMessageUseCase
 from app.application.use_cases.list_users import ListUsersUseCase
+from app.application.use_cases.mission_orchestrator import MissionOrchestrator
 from app.application.use_cases.process_battery_telemetry import ProcessBatteryTelemetryUseCase
 from app.application.use_cases.process_emergency_telemetry import ProcessEmergencyTelemetryUseCase
 from app.application.use_cases.process_navigation_eta import ProcessNavigationEtaUseCase
@@ -44,6 +45,8 @@ from app.infrastructure.rosbridge.mqtt_rosbridge_bridge import MqttRosbridgeBrid
 from app.infrastructure.repositories.in_memory_settings_repository import InMemorySettingsRepository
 from app.infrastructure.repositories.in_memory_user_repository import InMemoryUserRepository
 from app.infrastructure.repositories.in_memory_robot_state_repository import InMemoryRobotStateRepository
+from app.infrastructure.repositories.in_memory_mission_repository import InMemoryMissionRepository
+from app.infrastructure.repositories.sqlalchemy_mission_repository import SqlAlchemyMissionRepository
 from app.infrastructure.repositories.sqlalchemy_settings_repository import SqlAlchemySettingsRepository
 from app.infrastructure.repositories.sqlalchemy_user_repository import SqlAlchemyUserRepository
 from app.infrastructure.security.jwt_token_service import JwtTokenService
@@ -77,6 +80,18 @@ OPENAPI_TAGS = [
     {
         "name": "robot commands",
         "description": "Authenticated robot commands published to MQTT for the robot rosbridge adapter.",
+    },
+    {
+        "name": "annotated points",
+        "description": "Admin-managed reusable map points for stock, delivery rooms, and robot base.",
+    },
+    {
+        "name": "missions",
+        "description": "CareBot delivery mission creation, queueing, confirmations, and cancellation.",
+    },
+    {
+        "name": "robot screen",
+        "description": "Read-only robot onboard screen status protected by a dedicated token.",
     },
     {
         "name": "navigation",
@@ -131,6 +146,16 @@ def create_settings_repository(default_settings: RobotSettings) -> SettingsRepos
     raise ValueError("SETTINGS_REPOSITORY_BACKEND must be 'memory' or 'database'")
 
 
+def create_mission_repository():
+    if settings.mission_repository_backend == "memory":
+        return InMemoryMissionRepository()
+
+    if settings.mission_repository_backend == "database":
+        return SqlAlchemyMissionRepository(session_factory=SessionLocal)
+
+    raise ValueError("MISSION_REPOSITORY_BACKEND must be 'memory' or 'database'")
+
+
 def create_app() -> FastAPI:
     robot_state_repository = InMemoryRobotStateRepository()
     password_hasher = PasswordHasher()
@@ -142,6 +167,7 @@ def create_app() -> FastAPI:
     )
     user_repository = create_user_repository(password_hasher)
     settings_repository = create_settings_repository(create_default_robot_settings())
+    mission_repository = create_mission_repository()
     mqtt_service = MQTTService(settings=settings)
     robot_rosbridge_bridge = MqttRosbridgeBridge(settings=settings)
     robot_dashboard_client = RobotDashboardClient(settings.robot_dashboard_url)
@@ -158,15 +184,26 @@ def create_app() -> FastAPI:
         low_battery_threshold=settings.low_battery_threshold,
         auto_return_enabled=settings.auto_return_enabled,
     )
-    process_emergency_telemetry = ProcessEmergencyTelemetryUseCase(robot_state_repository)
-    process_robot_status_telemetry = ProcessRobotStatusTelemetryUseCase(robot_state_repository)
+    mission_orchestrator = MissionOrchestrator(
+        annotated_points=mission_repository,
+        missions=mission_repository,
+        command_publisher=robot_command_publisher,
+        message_publisher=mqtt_service,
+        state_repository=robot_state_repository,
+        settings_repository=settings_repository,
+        arrival_radius_m=settings.mission_arrival_radius_m,
+    )
+    process_emergency_telemetry = ProcessEmergencyTelemetryUseCase(robot_state_repository, mission_orchestrator)
+    process_robot_status_telemetry = ProcessRobotStatusTelemetryUseCase(robot_state_repository, mission_orchestrator)
     trigger_emergency_stop = TriggerEmergencyStopUseCase(
         state_repository=robot_state_repository,
         message_publisher=mqtt_service,
+        mission_orchestrator=mission_orchestrator,
     )
     clear_emergency = ClearEmergencyUseCase(
         state_repository=robot_state_repository,
         message_publisher=mqtt_service,
+        mission_orchestrator=mission_orchestrator,
     )
     use_cases = ApplicationUseCases(
         get_robot_status=GetRobotStatusUseCase(robot_state_repository),
@@ -195,6 +232,9 @@ def create_app() -> FastAPI:
             state_repository=robot_state_repository,
             settings_repository=settings_repository,
         ),
+        annotated_points=mission_repository,
+        missions=mission_repository,
+        mission_orchestrator=mission_orchestrator,
     )
     handle_mqtt_message = HandleMqttMessageUseCase(
         process_battery_telemetry=process_battery_telemetry,

--- a/backend/app/presentation/api/dependencies.py
+++ b/backend/app/presentation/api/dependencies.py
@@ -93,3 +93,22 @@ def require_robot_api_key(api_key: Annotated[str | None, Header(alias="X-Robot-A
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Robot API key is not configured")
     if not hmac.compare_digest(api_key or "", settings.robot_api_key):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid robot API key")
+
+
+def require_robot_screen_token(
+    token: Annotated[str | None, Header(alias="X-Robot-Screen-Token")] = None,
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> None:
+    configured_token = settings.robot_screen_token
+    if configured_token is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Robot screen token is not configured")
+
+    provided_token = token or ""
+    if not provided_token and authorization and authorization.lower().startswith("bearer "):
+        provided_token = authorization[7:].strip()
+
+    if not hmac.compare_digest(provided_token, configured_token):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid robot screen token")
+
+
+RobotScreenTokenDep = Annotated[None, Depends(require_robot_screen_token)]

--- a/backend/app/presentation/api/v1/endpoints/annotated_points.py
+++ b/backend/app/presentation/api/v1/endpoints/annotated_points.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Annotated
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Path, Query, status
+
+from app.application.dto.mission_dto import (
+    AnnotatedPointCreateRequest,
+    AnnotatedPointResponse,
+    AnnotatedPointType,
+    AnnotatedPointUpdateRequest,
+    StockPointSuppliesUpdateRequest,
+    StockPointSupplyResponse,
+)
+from app.domain.entities.mission import AnnotatedPoint, AnnotatedPointType as DomainPointType, StockPointSupply, utc_now
+from app.presentation.api.dependencies import AdminUserDep, CaregiverOrAdminDep, UseCasesDep
+
+router = APIRouter(prefix="/annotated-points", tags=["annotated points"])
+
+
+@router.get("", response_model=list[AnnotatedPointResponse])
+def list_annotated_points(
+    use_cases: UseCasesDep,
+    _current_user: CaregiverOrAdminDep,
+    point_type: Annotated[AnnotatedPointType | None, Query(alias="type")] = None,
+    active_only: Annotated[bool, Query()] = False,
+) -> list[AnnotatedPointResponse]:
+    points = use_cases.annotated_points.list_points(point_type=point_type, active_only=active_only)
+    return [AnnotatedPointResponse.from_domain(point) for point in points]
+
+
+@router.post("", response_model=AnnotatedPointResponse, status_code=status.HTTP_201_CREATED)
+def create_annotated_point(
+    use_cases: UseCasesDep,
+    _current_user: AdminUserDep,
+    payload: AnnotatedPointCreateRequest,
+) -> AnnotatedPointResponse:
+    now = utc_now()
+    point = AnnotatedPoint(
+        id=f"pt-{uuid4()}",
+        name=payload.name.strip(),
+        type=payload.type,
+        x=payload.x,
+        y=payload.y,
+        yaw=payload.yaw,
+        is_active=payload.is_active,
+        created_at=now,
+        updated_at=now,
+    )
+    return AnnotatedPointResponse.from_domain(use_cases.annotated_points.create_point(point))
+
+
+@router.patch("/{point_id}", response_model=AnnotatedPointResponse)
+def update_annotated_point(
+    use_cases: UseCasesDep,
+    _current_user: AdminUserDep,
+    payload: AnnotatedPointUpdateRequest,
+    point_id: Annotated[str, Path(min_length=1)],
+) -> AnnotatedPointResponse:
+    point = use_cases.annotated_points.get_point(point_id)
+    if point is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Annotated point not found")
+
+    updated = replace(
+        point,
+        name=payload.name.strip() if payload.name is not None else point.name,
+        type=payload.type if payload.type is not None else point.type,
+        x=payload.x if payload.x is not None else point.x,
+        y=payload.y if payload.y is not None else point.y,
+        yaw=payload.yaw if payload.yaw is not None else point.yaw,
+        is_active=payload.is_active if payload.is_active is not None else point.is_active,
+    )
+    return AnnotatedPointResponse.from_domain(use_cases.annotated_points.update_point(updated))
+
+
+@router.delete("/{point_id}", response_model=AnnotatedPointResponse)
+def deactivate_annotated_point(
+    use_cases: UseCasesDep,
+    _current_user: AdminUserDep,
+    point_id: Annotated[str, Path(min_length=1)],
+) -> AnnotatedPointResponse:
+    point = use_cases.annotated_points.deactivate_point(point_id)
+    if point is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Annotated point not found")
+    return AnnotatedPointResponse.from_domain(point)
+
+
+@router.get("/{point_id}/supplies", response_model=list[StockPointSupplyResponse])
+def list_stock_supplies(
+    use_cases: UseCasesDep,
+    _current_user: CaregiverOrAdminDep,
+    point_id: Annotated[str, Path(min_length=1)],
+) -> list[StockPointSupplyResponse]:
+    point = use_cases.annotated_points.get_point(point_id)
+    if point is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Annotated point not found")
+    supplies = use_cases.annotated_points.list_stock_supplies(stock_point_id=point_id, active_only=True)
+    return [StockPointSupplyResponse.from_domain(supply) for supply in supplies]
+
+
+@router.put("/{point_id}/supplies", response_model=list[StockPointSupplyResponse])
+def replace_stock_supplies(
+    use_cases: UseCasesDep,
+    _current_user: AdminUserDep,
+    payload: StockPointSuppliesUpdateRequest,
+    point_id: Annotated[str, Path(min_length=1)],
+) -> list[StockPointSupplyResponse]:
+    point = use_cases.annotated_points.get_point(point_id)
+    if point is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Annotated point not found")
+    if point.type != DomainPointType.stock:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Supplies can only be configured on STOCK points")
+
+    seen_supply_types = set()
+    supplies: list[StockPointSupply] = []
+    for item in payload.supplies:
+        if item.supply_type in seen_supply_types:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Duplicate supply type")
+        seen_supply_types.add(item.supply_type)
+        supplies.append(
+            StockPointSupply(
+                stock_point_id=point_id,
+                supply_type=item.supply_type,
+                priority_order=item.priority_order,
+                is_active=item.is_active,
+            )
+        )
+
+    updated = use_cases.annotated_points.replace_stock_supplies(point_id, supplies)
+    return [StockPointSupplyResponse.from_domain(supply) for supply in updated]

--- a/backend/app/presentation/api/v1/endpoints/missions.py
+++ b/backend/app/presentation/api/v1/endpoints/missions.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Path, Query, status
+
+from app.application.dto.mission_dto import MissionCreateRequest, MissionResponse
+from app.application.use_cases.mission_orchestrator import MissionNotFoundError, MissionTransitionError, MissionValidationError
+from app.presentation.api.dependencies import CaregiverOrAdminDep, UseCasesDep
+
+router = APIRouter(prefix="/missions", tags=["missions"])
+
+
+def _mission_error_to_http(exc: Exception) -> HTTPException:
+    if isinstance(exc, MissionNotFoundError):
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    if isinstance(exc, MissionTransitionError):
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@router.get("", response_model=list[MissionResponse])
+def list_missions(
+    use_cases: UseCasesDep,
+    _current_user: CaregiverOrAdminDep,
+    include_terminal: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+) -> list[MissionResponse]:
+    missions = use_cases.missions.list_missions(include_terminal=include_terminal, limit=limit)
+    return [MissionResponse.from_domain(mission) for mission in missions]
+
+
+@router.post("", response_model=MissionResponse, status_code=status.HTTP_201_CREATED)
+def create_mission(
+    use_cases: UseCasesDep,
+    current_user: CaregiverOrAdminDep,
+    payload: MissionCreateRequest,
+) -> MissionResponse:
+    try:
+        mission = use_cases.mission_orchestrator.create_mission(payload.supply_type, payload.delivery_room_id, current_user)
+    except (MissionValidationError, MissionTransitionError, MissionNotFoundError) as exc:
+        raise _mission_error_to_http(exc) from None
+    return MissionResponse.from_domain(mission)
+
+
+@router.post("/{mission_id}/confirm-recovery", response_model=MissionResponse)
+def confirm_recovery(
+    use_cases: UseCasesDep,
+    current_user: CaregiverOrAdminDep,
+    mission_id: Annotated[str, Path(min_length=1)],
+) -> MissionResponse:
+    try:
+        mission = use_cases.mission_orchestrator.confirm_recovery(mission_id, current_user)
+    except (MissionValidationError, MissionTransitionError, MissionNotFoundError) as exc:
+        raise _mission_error_to_http(exc) from None
+    return MissionResponse.from_domain(mission)
+
+
+@router.post("/{mission_id}/confirm-delivery", response_model=MissionResponse)
+def confirm_delivery(
+    use_cases: UseCasesDep,
+    current_user: CaregiverOrAdminDep,
+    mission_id: Annotated[str, Path(min_length=1)],
+) -> MissionResponse:
+    try:
+        mission = use_cases.mission_orchestrator.confirm_delivery(mission_id, current_user)
+    except (MissionValidationError, MissionTransitionError, MissionNotFoundError) as exc:
+        raise _mission_error_to_http(exc) from None
+    return MissionResponse.from_domain(mission)
+
+
+@router.post("/{mission_id}/cancel", response_model=MissionResponse)
+def cancel_mission(
+    use_cases: UseCasesDep,
+    current_user: CaregiverOrAdminDep,
+    mission_id: Annotated[str, Path(min_length=1)],
+) -> MissionResponse:
+    try:
+        mission = use_cases.mission_orchestrator.cancel_mission(mission_id, current_user)
+    except (MissionValidationError, MissionTransitionError, MissionNotFoundError) as exc:
+        raise _mission_error_to_http(exc) from None
+    return MissionResponse.from_domain(mission)

--- a/backend/app/presentation/api/v1/endpoints/robot_screen.py
+++ b/backend/app/presentation/api/v1/endpoints/robot_screen.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.application.dto.mission_dto import RobotScreenMission, RobotScreenStatusResponse
+from app.domain.entities.mission import Mission, MissionStatus, SupplyType, utc_now
+from app.presentation.api.dependencies import RobotScreenTokenDep, UseCasesDep
+
+router = APIRouter(prefix="/robot-screen", tags=["robot screen"])
+
+SUPPLY_LABELS_FR = {
+    SupplyType.serviettes: "Serviettes",
+    SupplyType.papier_toilette: "Papier toilette",
+    SupplyType.gants: "Gants",
+    SupplyType.protections: "Protections",
+    SupplyType.linge: "Linge",
+}
+
+STATUS_TITLES_FR = {
+    MissionStatus.pending: "Mission en attente",
+    MissionStatus.navigating_to_stock: "En route vers le stock",
+    MissionStatus.waiting_for_recovery_confirmation: "En attente de récupération",
+    MissionStatus.navigating_to_delivery: "En route vers la chambre",
+    MissionStatus.waiting_for_delivery_confirmation: "En attente de confirmation",
+    MissionStatus.completed: "Livraison terminée",
+    MissionStatus.cancelled: "Mission annulée",
+    MissionStatus.failed: "Mission en échec",
+}
+
+
+@router.get("/status", response_model=RobotScreenStatusResponse)
+def get_robot_screen_status(use_cases: UseCasesDep, _token: RobotScreenTokenDep) -> RobotScreenStatusResponse:
+    robot_status = use_cases.get_robot_status.execute()
+    if robot_status.emergency_active:
+        return RobotScreenStatusResponse(
+            robot_state="EMERGENCY_STOP",
+            screen_title_fr="Arrêt d'urgence",
+            screen_message_fr="CareBot est immobilisé. Un administrateur doit réinitialiser l'arrêt d'urgence.",
+            current_mission=None,
+            updated_at=robot_status.timestamp,
+        )
+
+    mission = use_cases.missions.get_active_mission() or use_cases.missions.get_oldest_pending_mission()
+    if mission is None:
+        return RobotScreenStatusResponse(
+            robot_state="IDLE",
+            screen_title_fr="CareBot",
+            screen_message_fr="Prêt à aider l'équipe soignante",
+            current_mission=None,
+            updated_at=robot_status.timestamp or utc_now(),
+        )
+
+    return RobotScreenStatusResponse(
+        robot_state="MISSION_ACTIVE" if mission.status != MissionStatus.pending else "MISSION_PENDING",
+        screen_title_fr=STATUS_TITLES_FR[mission.status],
+        screen_message_fr=_message_for(mission),
+        current_mission=RobotScreenMission(
+            id=mission.id,
+            status=mission.status,
+            supply_label_fr=SUPPLY_LABELS_FR[mission.supply_type],
+            destination_label_fr=mission.delivery_room_name_snapshot,
+        ),
+        updated_at=robot_status.timestamp or utc_now(),
+    )
+
+
+def _message_for(mission: Mission) -> str:
+    supply = SUPPLY_LABELS_FR[mission.supply_type].lower()
+    if mission.status == MissionStatus.pending:
+        return f"Mission planifiée pour livrer {supply} à {mission.delivery_room_name_snapshot}."
+    if mission.status == MissionStatus.navigating_to_stock:
+        return f"CareBot va récupérer {supply} au stock."
+    if mission.status == MissionStatus.waiting_for_recovery_confirmation:
+        return f"Merci de confirmer la récupération de {supply}."
+    if mission.status == MissionStatus.navigating_to_delivery:
+        return f"CareBot livre {supply} vers {mission.delivery_room_name_snapshot}."
+    if mission.status == MissionStatus.waiting_for_delivery_confirmation:
+        return f"Merci de confirmer la livraison à {mission.delivery_room_name_snapshot}."
+    if mission.status == MissionStatus.failed:
+        return "Mission interrompue. Une intervention est nécessaire."
+    if mission.status == MissionStatus.cancelled:
+        return "Mission annulée."
+    return "Livraison terminée."

--- a/backend/app/presentation/api/v1/router.py
+++ b/backend/app/presentation/api/v1/router.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app.presentation.api.v1.endpoints import admin_settings, admin_users, auth, navigation, robot, robot_commands, robot_maps, robot_media, safety
+from app.presentation.api.v1.endpoints import admin_settings, admin_users, annotated_points, auth, missions, navigation, robot, robot_commands, robot_maps, robot_media, robot_screen, safety
 
 api_router = APIRouter(prefix="/api")
 api_router.include_router(admin_settings.router)
 api_router.include_router(admin_users.router)
+api_router.include_router(annotated_points.router)
 api_router.include_router(auth.router)
+api_router.include_router(missions.router)
 api_router.include_router(navigation.router)
 api_router.include_router(robot.router)
 api_router.include_router(robot_commands.router)
 api_router.include_router(robot_maps.router)
 api_router.include_router(robot_media.router)
+api_router.include_router(robot_screen.router)
 api_router.include_router(safety.router)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("MQTT_ENABLED", "false")
+os.environ.setdefault("MISSION_REPOSITORY_BACKEND", "memory")
+os.environ.setdefault("ROBOT_SCREEN_TOKEN", "robot-screen-test-token")
 
 from app.main import create_app
 from tests.helpers import ADMIN_EMAIL, ADMIN_PASSWORD, CAREGIVER_PASSWORD, auth_headers, login

--- a/backend/tests/test_mission_control_endpoints.py
+++ b/backend/tests/test_mission_control_endpoints.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi.testclient import TestClient
+
+from app.domain.entities.robot import RobotPose, RobotRuntimeTelemetry
+from tests.helpers import auth_headers, login
+
+
+def test_mission_api_runs_create_arrive_confirm_complete_flow(
+    client: TestClient,
+    admin_token: str,
+    create_caregiver: Callable[[str], tuple[str, str, str]],
+) -> None:
+    reset_response = client.post("/api/safety/emergency/reset", headers=auth_headers(admin_token))
+    assert reset_response.status_code == 200
+
+    stock = client.post(
+        "/api/annotated-points",
+        headers=auth_headers(admin_token),
+        json={"name": "Stock principal", "type": "STOCK", "x": 1.0, "y": 1.0, "yaw": 0.0},
+    )
+    assert stock.status_code == 201
+    stock_id = stock.json()["id"]
+
+    supplies = client.put(
+        f"/api/annotated-points/{stock_id}/supplies",
+        headers=auth_headers(admin_token),
+        json={"supplies": [{"supply_type": "gants", "priority_order": 1}]},
+    )
+    assert supplies.status_code == 200
+
+    delivery_room = client.post(
+        "/api/annotated-points",
+        headers=auth_headers(admin_token),
+        json={"name": "Chambre 203", "type": "DELIVERY_ROOM", "x": 3.0, "y": 3.0, "yaw": 0.0},
+    )
+    assert delivery_room.status_code == 201
+
+    _, email, password = create_caregiver()
+    caregiver_token = login(client, email, password)
+    mission_response = client.post(
+        "/api/missions",
+        headers=auth_headers(caregiver_token),
+        json={"supply_type": "gants", "delivery_room_id": delivery_room.json()["id"]},
+    )
+    assert mission_response.status_code == 201
+    mission = mission_response.json()
+    mission_id = mission["id"]
+    assert mission["status"] == "NAVIGATING_TO_STOCK"
+    assert mission["stock_point_id"] == stock_id
+
+    client.app.state.use_cases.process_robot_status_telemetry.execute(
+        RobotRuntimeTelemetry(pose=RobotPose(x=1.1, y=1.0, yaw=0.0))
+    )
+    missions_after_stock_arrival = client.get("/api/missions", headers=auth_headers(caregiver_token)).json()
+    assert missions_after_stock_arrival[0]["status"] == "WAITING_FOR_RECOVERY_CONFIRMATION"
+
+    recovery = client.post(f"/api/missions/{mission_id}/confirm-recovery", headers=auth_headers(caregiver_token))
+    assert recovery.status_code == 200
+    assert recovery.json()["status"] == "NAVIGATING_TO_DELIVERY"
+
+    client.app.state.use_cases.process_robot_status_telemetry.execute(
+        RobotRuntimeTelemetry(pose=RobotPose(x=3.0, y=3.0, yaw=0.0))
+    )
+    missions_after_delivery_arrival = client.get("/api/missions", headers=auth_headers(caregiver_token)).json()
+    assert missions_after_delivery_arrival[0]["status"] == "WAITING_FOR_DELIVERY_CONFIRMATION"
+
+    delivery = client.post(f"/api/missions/{mission_id}/confirm-delivery", headers=auth_headers(caregiver_token))
+    assert delivery.status_code == 200
+    assert delivery.json()["status"] == "COMPLETED"
+
+
+def test_annotated_point_writes_are_admin_only(
+    client: TestClient,
+    create_caregiver: Callable[[str], tuple[str, str, str]],
+) -> None:
+    _, email, password = create_caregiver()
+    caregiver_token = login(client, email, password)
+
+    response = client.post(
+        "/api/annotated-points",
+        headers=auth_headers(caregiver_token),
+        json={"name": "Stock interdit", "type": "STOCK", "x": 0, "y": 0, "yaw": 0},
+    )
+
+    assert response.status_code == 403
+
+
+def test_robot_screen_status_requires_dedicated_token(client: TestClient) -> None:
+    unauthorized = client.get("/api/robot-screen/status")
+    assert unauthorized.status_code == 403
+
+    authorized = client.get("/api/robot-screen/status", headers={"X-Robot-Screen-Token": "robot-screen-test-token"})
+    assert authorized.status_code == 200
+    assert authorized.json()["screen_title_fr"]

--- a/docs/adr/0001-embed-foxglove-in-control.md
+++ b/docs/adr/0001-embed-foxglove-in-control.md
@@ -1,0 +1,10 @@
+# Embed Foxglove in Control
+
+We will replace the axis-based control map with a real embedded Foxglove Web/Studio interface on `/control` if embedding is technically possible, connected to `ws://10.10.220.180:8765` through `foxglove_bridge`. Foxglove is the chosen operational map surface because it already supports ROS map visualization patterns used by the M3Pro course, while mission creation and robot commands remain mediated by the Health Robot application and backend security model.
+
+## Consequences
+
+- `/control` becomes the operational mission page, while `/map` remains the mapping/admin page.
+- The application must treat Foxglove as visualization only, not as the owner of mission state or mission commands.
+- The Foxglove bridge is an explicit exception to the usual frontend/backend boundary for visualization; mission commands must still go through the backend.
+- Mission creation, reusable annotated points, and delivery workflow remain Health Robot domain concepts.

--- a/docs/mission-control-implementation-plan.md
+++ b/docs/mission-control-implementation-plan.md
@@ -1,0 +1,469 @@
+# Mission Control Implementation Plan
+
+## Goal
+
+Replace the current free-coordinate `/control` page with a backend-owned operational mission interface for CareBot delivery missions.
+
+The MVP proves the complete loop: create a mission, route to stock, wait for recovery confirmation, route to delivery room, wait for delivery confirmation, complete the mission, then start the next queued mission if one exists.
+
+## Fixed Decisions
+
+- The backend is the source of truth for mission state.
+- Mission state, annotated points, stock configuration, confirmations, cancellation and history are persisted in the database.
+- New persisted tables are introduced through Alembic migrations.
+- `/control` is the main operational mission page.
+- `/map` remains the admin mapping/configuration page.
+- `/robot-screen` is a dedicated web route for the robot onboard screen.
+- `/robot-screen` is protected by a dedicated robot-screen token, not by a human login.
+- The robot screen displays French labels.
+- Foxglove is visualization only. Mission commands stay in the Health Robot backend.
+- Foxglove embedding is not blocking for MVP. If embedding is not feasible quickly, `/control` shows an “open Foxglove” action.
+- Mission orchestration is event-driven, not a background polling loop.
+- Robot arrival is detected by backend pose proximity to the active target.
+- Human confirmation is required for recovery and delivery.
+- Recovery and delivery wait states have no automatic timeout in the MVP.
+- The future scan feature can later automate or replace the recovery confirmation.
+- Multiple missions can be queued, but only one mission can be active at a time.
+- The queued mission order is FIFO for MVP.
+- Navigation free-form coordinates are removed from the operational `/control` flow.
+
+## Domain Model
+
+### Supply Type
+
+Supported supplies are fixed for the MVP:
+
+- `serviettes`
+- `papier_toilette`
+- `gants`
+- `protections`
+- `linge`
+
+### Annotated Point
+
+An annotated point is a reusable map point created by an admin.
+
+Point types:
+
+- `STOCK`
+- `DELIVERY_ROOM`
+- `ROBOT_BASE`
+
+Minimum fields:
+
+- `id`
+- `name`
+- `type`
+- `x`
+- `y`
+- `yaw`
+- `is_active`
+- `created_at`
+- `updated_at`
+
+Rules:
+
+- Admins create, edit and deactivate annotated points on `/map`.
+- Caregivers do not create or edit annotated points.
+- Missions reference existing active `DELIVERY_ROOM` points.
+- Points are soft-deactivated instead of hard-deleted if they have been referenced by missions.
+- A mission stores the selected point IDs and coordinate snapshots so later point edits do not change an already-created mission.
+
+### Stock Configuration
+
+A stock point can contain multiple supplies.
+
+Minimum model:
+
+- `stock_point_id`
+- `supply_type`
+- `priority_order`
+- `is_active`
+
+Rules:
+
+- The backend chooses the first active compatible stock by `priority_order`.
+- No admin override stock selection in MVP.
+- If no active stock can provide the requested supply, mission creation fails with a clear validation error.
+
+### Mission
+
+Mission state is separate from `RobotMode`.
+
+Mission statuses:
+
+```text
+PENDING
+NAVIGATING_TO_STOCK
+WAITING_FOR_RECOVERY_CONFIRMATION
+NAVIGATING_TO_DELIVERY
+WAITING_FOR_DELIVERY_CONFIRMATION
+COMPLETED
+CANCELLED
+FAILED
+```
+
+Minimum fields:
+
+- `id`
+- `status`
+- `supply_type`
+- `delivery_room_id`
+- `delivery_room_name_snapshot`
+- `delivery_x_snapshot`
+- `delivery_y_snapshot`
+- `delivery_yaw_snapshot`
+- `stock_point_id`
+- `stock_point_name_snapshot`
+- `stock_x_snapshot`
+- `stock_y_snapshot`
+- `stock_yaw_snapshot`
+- `created_by_user_id`
+- `created_by_name_snapshot`
+- `created_at`
+- `started_at`
+- `arrived_at_stock_at`
+- `recovery_confirmed_at`
+- `recovery_confirmed_by_user_id`
+- `arrived_at_delivery_at`
+- `delivery_confirmed_at`
+- `delivery_confirmed_by_user_id`
+- `completed_at`
+- `cancelled_at`
+- `cancelled_by_user_id`
+- `failure_reason`
+- `updated_at`
+
+## Mission Flow
+
+### Create Mission
+
+1. A caregiver or admin selects a supply and delivery room on `/control`.
+2. The backend validates the delivery room is an active `DELIVERY_ROOM`.
+3. The backend chooses the compatible stock point by active stock rule order.
+4. The backend persists the mission as `PENDING` with point snapshots.
+5. If no mission is active and the robot is not in emergency stop, the backend starts the next mission immediately.
+
+### Start Mission
+
+1. The oldest `PENDING` mission is selected.
+2. The mission becomes `NAVIGATING_TO_STOCK`.
+3. The backend publishes a navigation command to the stock snapshot coordinates.
+4. `RobotStatus.mission_id` uses the `Mission.id`, not the command id.
+
+### Arrive At Stock
+
+1. Robot pose telemetry updates the backend state.
+2. The mission orchestrator checks distance to the stock target.
+3. If distance is within `MISSION_ARRIVAL_RADIUS_M`, the mission becomes `WAITING_FOR_RECOVERY_CONFIRMATION`.
+4. The robot stays blocked in this state until a caregiver or admin confirms recovery.
+
+### Confirm Recovery
+
+1. A caregiver or admin confirms recovery from `/control`.
+2. The backend stores `recovery_confirmed_by_user_id` and `recovery_confirmed_at`.
+3. The mission becomes `NAVIGATING_TO_DELIVERY`.
+4. The backend publishes a navigation command to the delivery room snapshot coordinates.
+
+### Arrive At Delivery
+
+1. Robot pose telemetry updates the backend state.
+2. The mission orchestrator checks distance to the delivery target.
+3. If distance is within `MISSION_ARRIVAL_RADIUS_M`, the mission becomes `WAITING_FOR_DELIVERY_CONFIRMATION`.
+4. The robot stays blocked in this state until a caregiver or admin confirms delivery.
+
+### Confirm Delivery
+
+1. A caregiver or admin confirms delivery from `/control`.
+2. The backend stores `delivery_confirmed_by_user_id` and `delivery_confirmed_at`.
+3. The mission becomes `COMPLETED`.
+4. The robot remains at the delivery room.
+5. The backend starts the next queued mission if one exists.
+
+### Chained Missions
+
+- Chained missions start from the robot's current position.
+- The robot does not automatically return to base between missions.
+- Return base remains an explicit admin action.
+
+## Cancellation Rules
+
+```text
+PENDING
+-> CANCELLED
+-> no robot command
+
+NAVIGATING_TO_STOCK
+-> CANCELLED
+-> cancel Nav2 and publish zero twist
+
+WAITING_FOR_RECOVERY_CONFIRMATION
+-> CANCELLED
+-> no navigation is in progress; robot remains at stock
+
+NAVIGATING_TO_DELIVERY
+-> CANCELLED
+-> cancel Nav2 and publish zero twist
+-> supply may already be on the robot; admin intervention may be needed
+
+WAITING_FOR_DELIVERY_CONFIRMATION
+-> CANCELLED
+-> robot remains at the delivery room; delivery is not confirmed
+
+COMPLETED / CANCELLED / FAILED
+-> not cancellable
+```
+
+Annulation does not mean return base.
+
+## Emergency And Failure Rules
+
+- Emergency stop remains available to caregivers and admins.
+- Emergency reset remains admin-only.
+- The mission orchestrator must not publish non-emergency navigation while `emergency_active=true`.
+- If emergency stop occurs during an active navigation step, the MVP should move the active mission to `FAILED` with `failure_reason="emergency_stop"` unless the implementation can safely prove the mission is still waiting for human confirmation.
+- After emergency reset, the backend may start the next `PENDING` mission only if there is no active non-terminal mission.
+- No automatic mission resume after emergency in MVP.
+
+## Backend Orchestration
+
+The mission orchestrator is invoked by events:
+
+- Mission created.
+- Recovery confirmed.
+- Delivery confirmed.
+- Mission cancelled.
+- Robot pose updated.
+- Emergency reset completed.
+
+The orchestrator does not run as a periodic background loop in MVP.
+
+Core operations:
+
+- `try_start_next_mission()`
+- `handle_robot_pose_updated(pose)`
+- `confirm_recovery(mission_id, actor)`
+- `confirm_delivery(mission_id, actor)`
+- `cancel_mission(mission_id, actor)`
+- `fail_active_mission(reason)`
+
+Concurrency rules:
+
+- At most one mission can be in a non-terminal active status other than `PENDING`.
+- Mission selection uses `created_at ASC`.
+- State transitions should be guarded in the repository/use case layer to prevent double confirmations.
+
+## Backend API
+
+### Annotated Points
+
+Admin write access:
+
+```text
+GET    /api/annotated-points
+POST   /api/annotated-points
+PATCH  /api/annotated-points/{point_id}
+DELETE /api/annotated-points/{point_id}
+```
+
+Rules:
+
+- `GET` can be caregiver/admin because `/control` needs active delivery rooms.
+- `POST`, `PATCH`, `DELETE` are admin-only.
+- `DELETE` should soft-deactivate.
+
+### Stock Supplies
+
+Admin write access:
+
+```text
+PUT /api/annotated-points/{point_id}/supplies
+```
+
+Rules:
+
+- Only valid for `STOCK` points.
+- Replaces active supply configuration for that stock point.
+
+### Missions
+
+Caregiver/admin access:
+
+```text
+GET  /api/missions
+POST /api/missions
+POST /api/missions/{mission_id}/confirm-recovery
+POST /api/missions/{mission_id}/confirm-delivery
+POST /api/missions/{mission_id}/cancel
+```
+
+Rules:
+
+- Caregivers and admins can view all active missions.
+- Caregivers and admins can confirm recovery and delivery for any active mission.
+- The creator is stored for traceability but is not required for confirmation.
+- Admin-only force/fix actions can be added later if needed.
+
+### Robot Screen
+
+Robot-screen token access:
+
+```text
+GET /api/robot-screen/status
+```
+
+Rules:
+
+- Protected by `ROBOT_SCREEN_TOKEN`.
+- Returns display-oriented data, not raw admin data.
+- `/robot-screen` polls this endpoint every 2 seconds.
+- SSE/WebSocket can be added later without changing the mission model.
+
+Example response shape:
+
+```json
+{
+  "robot_state": "MISSION_ACTIVE",
+  "screen_title_fr": "En route vers le stock",
+  "screen_message_fr": "CareBot va récupérer des gants.",
+  "current_mission": {
+    "id": "mis_...",
+    "status": "NAVIGATING_TO_STOCK",
+    "supply_label_fr": "Gants",
+    "destination_label_fr": "Chambre 203"
+  },
+  "updated_at": "2026-06-19T12:00:00Z"
+}
+```
+
+## Robot Screen French Labels
+
+```text
+PENDING -> Mission en attente
+NAVIGATING_TO_STOCK -> En route vers le stock
+WAITING_FOR_RECOVERY_CONFIRMATION -> En attente de récupération
+NAVIGATING_TO_DELIVERY -> En route vers la chambre
+WAITING_FOR_DELIVERY_CONFIRMATION -> En attente de confirmation
+COMPLETED -> Livraison terminée
+CANCELLED -> Mission annulée
+FAILED -> Mission en échec
+```
+
+Idle display:
+
+```text
+CareBot
+Prêt à aider l'équipe soignante
+```
+
+## Frontend Plan
+
+### `/map`
+
+- Add admin UI for annotated points.
+- Allow point creation from map coordinates if map data is available.
+- Allow editing name, type, pose and active state.
+- Allow stock supply configuration for `STOCK` points.
+- Keep existing mapping/admin behavior separate from mission operations.
+
+### `/control`
+
+- Replace the current free-coordinate navigation panel with mission controls.
+- Show mission creation form with supply and delivery room.
+- Show active mission and FIFO queue.
+- Show recovery and delivery confirmation actions only in the matching states.
+- Show cancellation action according to the mission state.
+- Keep emergency stop visible.
+- Show Foxglove visualization panel or fallback link/new-tab action.
+- Do not expose free-coordinate navigation to caregivers in the operational flow.
+
+### `/robot-screen`
+
+- Fullscreen, simple, French-first display.
+- Read-only.
+- Stores robot-screen token locally after first use.
+- Polls `/api/robot-screen/status` every 2 seconds.
+- No command buttons.
+
+### Existing Fake Mission Pages
+
+- Remove or stop relying on local `robot-context` mission state.
+- `/missions` can become a read-only mission history later.
+- `/deliveries` can become delivery statistics later.
+- These pages are not required for the first vertical slice if `/control` is complete.
+
+## Persistence And Migration
+
+Add SQLAlchemy models and Alembic migration for:
+
+- `annotated_points`
+- `stock_point_supplies`
+- `missions`
+
+Repository plan:
+
+- Domain repository interfaces for annotated points and missions.
+- SQLAlchemy implementations for production.
+- In-memory implementations only if useful for fast unit tests.
+
+Configuration additions:
+
+- `MISSION_ARRIVAL_RADIUS_M`, default `0.60`.
+- `ROBOT_SCREEN_TOKEN`, required when `/robot-screen` is enabled.
+- Optional frontend env for Foxglove URL or robot rosbridge URL.
+
+## Acceptance Criteria
+
+- Admin can create a stock point, delivery room and robot base on `/map`.
+- Admin can assign supported supplies to a stock point.
+- Caregiver can create a mission from `/control` by choosing supply and delivery room.
+- Backend persists the mission and selects the stock point automatically.
+- If robot is free, backend immediately starts the mission and publishes navigation to stock.
+- Backend detects stock arrival by pose proximity.
+- `/control` shows recovery confirmation only after stock arrival.
+- Confirming recovery publishes navigation to the delivery room.
+- Backend detects delivery arrival by pose proximity.
+- `/control` shows delivery confirmation only after delivery arrival.
+- Confirming delivery completes the mission.
+- If another mission is queued, backend starts it automatically.
+- `/robot-screen` shows French mission state labels and idle CareBot identity.
+- Foxglove is visible or openable, but mission flow works without it.
+- Free-coordinate navigation is not part of caregiver `/control`.
+
+## Test Plan
+
+- Unit-test mission state transitions.
+- Unit-test stock selection by supply and `priority_order`.
+- Unit-test FIFO mission selection.
+- Unit-test arrival detection radius.
+- Unit-test cancellation rules for each mission status.
+- Unit-test confirmation permissions and invalid-state rejection.
+- Integration-test mission creation through completion using repositories and mocked robot command publisher.
+- API-test caregiver/admin permissions for annotated points, missions and robot-screen access.
+- Frontend-test critical `/control` states if existing test setup supports it.
+
+## Implementation Order
+
+1. Add domain entities, repository interfaces and DTOs for annotated points and missions.
+2. Add SQLAlchemy models and Alembic migration.
+3. Add SQLAlchemy repositories.
+4. Add mission orchestrator use cases and tests.
+5. Wire mission orchestration into robot pose telemetry updates.
+6. Add annotated point and mission API endpoints.
+7. Add robot-screen status endpoint and token dependency.
+8. Add frontend API client functions and types.
+9. Update `/map` for annotated point and stock configuration.
+10. Replace `/control` with mission-first UI and Foxglove fallback panel.
+11. Add `/robot-screen` fullscreen display.
+12. Remove or neutralize fake local mission state from `robot-context` consumers.
+
+## Deferred Work
+
+- Automated recovery scan.
+- Priority or proximity-based scheduling.
+- Admin stock override.
+- SSE/WebSocket status streaming.
+- Analytics and delivery performance reporting.
+- Automatic return base after delivery.
+- Mission resume after emergency or backend restart.
+- Foxglove command integration.

--- a/docs/mission-control-simple-plan.md
+++ b/docs/mission-control-simple-plan.md
@@ -1,0 +1,72 @@
+# Plan Simple Mission Control
+
+## Objectif
+
+Remplacer le contrôle libre actuel par une vraie interface de mission pour CareBot.
+
+Le MVP doit permettre de faire une mission complète:
+
+1. Créer une mission.
+2. Envoyer le robot au stock.
+3. Confirmer la récupération.
+4. Envoyer le robot à la chambre.
+5. Confirmer la livraison.
+6. Terminer la mission.
+7. Lancer automatiquement la mission suivante si elle existe.
+
+## Plan
+
+1. **Créer le modèle backend**
+   Ajouter les notions de mission, point annoté, point de stock, chambre de livraison, fourniture et file de missions. Le backend devient la source de vérité.
+
+2. **Persister en base**
+   Ajouter les tables avec Alembic pour les missions, les points annotés et les fournitures disponibles dans chaque stock.
+
+3. **Ajouter l'orchestrateur mission**
+   Créer la logique qui fait avancer une mission: en attente, vers le stock, attente récupération, vers la chambre, attente confirmation, terminée.
+
+4. **Ajouter les APIs**
+   Ajouter les endpoints pour créer/listing les missions, confirmer la récupération, confirmer la livraison, annuler une mission, gérer les points annotés et alimenter l'écran robot.
+
+5. **Brancher la détection d'arrivée**
+   À chaque mise à jour de position robot, le backend vérifie si le robot est assez proche du stock ou de la chambre.
+
+6. **Mettre à jour `/map`**
+   Permettre aux admins de créer et modifier les points annotés: stock, chambre de livraison et base robot. Les admins configurent aussi les fournitures disponibles dans chaque stock.
+
+7. **Remplacer `/control`**
+   Retirer la navigation libre du flux principal. Ajouter la création de mission, la file active, la mission courante, les boutons de confirmation et l'annulation.
+
+8. **Ajouter `/robot-screen`**
+   Créer un écran plein écran en français pour le robot. Il affiche l'état courant via polling backend et ne contient aucun bouton de commande.
+
+9. **Ajouter Foxglove en visualisation**
+   Essayer l'intégration Foxglove dans `/control`. Si ce n'est pas fiable rapidement, afficher un bouton pour ouvrir Foxglove dans un nouvel onglet.
+
+10. **Tester le vertical slice**
+    Tester les transitions de mission, la sélection du stock, la file FIFO, les confirmations, les annulations, les permissions et la détection d'arrivée.
+
+## Règles MVP
+
+- Le backend possède l'état mission.
+- Les missions sont persistées.
+- Les missions en attente sont traitées en FIFO.
+- Une seule mission est active à la fois.
+- Les aides-soignants voient toutes les missions actives.
+- Les points annotés sont créés par les admins sur `/map`.
+- Le stock est choisi automatiquement selon la fourniture.
+- La récupération et la livraison demandent une confirmation humaine.
+- Il n'y a pas de timeout automatique MVP.
+- Le retour base reste une action explicite.
+- Foxglove est seulement une visualisation.
+- L'écran robot affiche les états en français.
+
+## Hors Scope MVP
+
+- Scan automatique de récupération.
+- Optimisation par priorité ou proximité.
+- Override manuel du stock.
+- SSE/WebSocket.
+- Retour base automatique.
+- Reprise automatique après arrêt d'urgence.
+- Commandes depuis Foxglove.

--- a/frontend/health-robot-front/src/components/Header.tsx
+++ b/frontend/health-robot-front/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from '@tanstack/react-router'
+import { Link, useNavigate, useRouterState } from '@tanstack/react-router'
 import { useState } from 'react'
 import { Activity, Gamepad2, Home, LayoutDashboard, LogIn, LogOut, Map, Menu, Settings, Shield, Users, X } from 'lucide-react'
 
@@ -19,10 +19,15 @@ const adminLinks = [
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false)
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
   const { user, isAuthenticated, logout } = useAuth()
   const navigate = useNavigate()
   const isAdmin = canUseAdminControls(user)
   const visibleLinks = isAuthenticated ? [...authenticatedLinks, ...(isAdmin ? adminLinks : [])] : []
+
+  if (pathname === '/robot-screen') {
+    return null
+  }
 
   const handleLogout = async () => {
     await logout()

--- a/frontend/health-robot-front/src/components/mission-map-view.tsx
+++ b/frontend/health-robot-front/src/components/mission-map-view.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef } from 'react'
+import { Layers3 } from 'lucide-react'
+
+import type { AnnotatedPoint, Mission, RobotMapSnapshot } from '@/lib/robot-api'
+import { cn } from '@/lib/utils'
+
+type RobotPose = { x: number; y: number; yaw?: number | null }
+
+interface MissionMapViewProps {
+  map: RobotMapSnapshot | null
+  pose?: RobotPose | null
+  points?: AnnotatedPoint[]
+  activeMission?: Mission | null
+  selectedPointId?: string | null
+  className?: string
+}
+
+const POINT_STYLE = {
+  STOCK: { color: '#34d399', label: 'S' },
+  DELIVERY_ROOM: { color: '#38bdf8', label: 'C' },
+  ROBOT_BASE: { color: '#fbbf24', label: 'B' },
+} as const
+
+export function MissionMapView({ map, pose = null, points = [], activeMission = null, selectedPointId = null, className }: MissionMapViewProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !map) return
+
+    canvas.width = map.width
+    canvas.height = map.height
+    const context = canvas.getContext('2d')
+    if (!context) return
+
+    drawOccupancyGrid(context, map)
+    if (activeMission) drawMissionRoute(context, map, activeMission)
+    drawAnnotatedPoints(context, map, points, selectedPointId)
+    if (activeMission) drawMissionTargets(context, map, activeMission)
+    if (pose) drawRobotPose(context, map, pose)
+  }, [activeMission, map, points, pose, selectedPointId])
+
+  if (!map) {
+    return (
+      <div className={cn('flex aspect-[4/3] items-center justify-center rounded-2xl border border-dashed border-white/10 bg-slate-950/60 p-8 text-center text-sm text-slate-400', className)}>
+        <div>
+          <Layers3 className="mx-auto mb-3 h-12 w-12 text-slate-500" />
+          <p className="font-semibold text-white">Aucune OccupancyGrid reçue</p>
+          <p className="mt-2">Démarre le mode mapping ou attends que le robot publie `/map`.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={cn('h-auto max-h-[68vh] w-full rounded-xl bg-slate-950 [image-rendering:pixelated]', className)}
+      style={{ aspectRatio: `${map.width} / ${map.height}` }}
+      aria-label="Carte mission du robot avec points annotés"
+    />
+  )
+}
+
+function drawOccupancyGrid(context: CanvasRenderingContext2D, map: RobotMapSnapshot) {
+  const image = context.createImageData(map.width, map.height)
+  for (let screenY = 0; screenY < map.height; screenY += 1) {
+    const sourceY = map.height - 1 - screenY
+    for (let x = 0; x < map.width; x += 1) {
+      const value = map.data[sourceY * map.width + x] ?? -1
+      const offset = (screenY * map.width + x) * 4
+      const [r, g, b] = occupancyColor(value)
+      image.data[offset] = r
+      image.data[offset + 1] = g
+      image.data[offset + 2] = b
+      image.data[offset + 3] = 255
+    }
+  }
+  context.putImageData(image, 0, 0)
+}
+
+function drawAnnotatedPoints(context: CanvasRenderingContext2D, map: RobotMapSnapshot, points: AnnotatedPoint[], selectedPointId: string | null) {
+  points.forEach((point, index) => {
+    const screen = mapToCanvas(map, point.x, point.y)
+    if (!isOnMap(map, screen)) return
+    const style = POINT_STYLE[point.type]
+    drawPin(context, screen.x, screen.y, {
+      color: style.color,
+      label: style.label,
+      title: point.name,
+      index: index + 1,
+      selected: selectedPointId === point.id,
+      inactive: !point.is_active,
+    })
+  })
+}
+
+function drawMissionRoute(context: CanvasRenderingContext2D, map: RobotMapSnapshot, mission: Mission) {
+  const stock = mapToCanvas(map, mission.stock_x_snapshot, mission.stock_y_snapshot)
+  const delivery = mapToCanvas(map, mission.delivery_x_snapshot, mission.delivery_y_snapshot)
+  if (!isOnMap(map, stock) && !isOnMap(map, delivery)) return
+
+  context.save()
+  context.strokeStyle = '#22d3ee'
+  context.lineWidth = Math.max(2, Math.min(map.width, map.height) / 110)
+  context.setLineDash([Math.max(5, map.width / 60), Math.max(4, map.width / 90)])
+  context.beginPath()
+  context.moveTo(stock.x, stock.y)
+  context.lineTo(delivery.x, delivery.y)
+  context.stroke()
+  context.restore()
+}
+
+function drawMissionTargets(context: CanvasRenderingContext2D, map: RobotMapSnapshot, mission: Mission) {
+  const stock = mapToCanvas(map, mission.stock_x_snapshot, mission.stock_y_snapshot)
+  const delivery = mapToCanvas(map, mission.delivery_x_snapshot, mission.delivery_y_snapshot)
+  if (isOnMap(map, stock)) {
+    drawPin(context, stock.x, stock.y, { color: '#34d399', label: '1', title: mission.stock_point_name_snapshot, selected: true })
+  }
+  if (isOnMap(map, delivery)) {
+    drawPin(context, delivery.x, delivery.y, { color: '#38bdf8', label: '2', title: mission.delivery_room_name_snapshot, selected: true })
+  }
+}
+
+function drawRobotPose(context: CanvasRenderingContext2D, map: RobotMapSnapshot, pose: RobotPose) {
+  const screen = mapToCanvas(map, pose.x, pose.y)
+  if (!isOnMap(map, screen)) return
+
+  context.save()
+  context.fillStyle = '#34d399'
+  context.strokeStyle = '#ecfeff'
+  context.lineWidth = Math.max(1, Math.min(map.width, map.height) / 90)
+  context.beginPath()
+  context.arc(screen.x, screen.y, Math.max(2, Math.min(map.width, map.height) / 35), 0, Math.PI * 2)
+  context.fill()
+  context.stroke()
+  const yaw = pose.yaw ?? 0
+  const length = Math.max(5, Math.min(map.width, map.height) / 12)
+  context.beginPath()
+  context.moveTo(screen.x, screen.y)
+  context.lineTo(screen.x + Math.cos(yaw) * length, screen.y - Math.sin(yaw) * length)
+  context.stroke()
+  context.restore()
+}
+
+function drawPin(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  options: { color: string; label: string; title: string; index?: number; selected?: boolean; inactive?: boolean },
+) {
+  const radius = Math.max(7, Math.min(context.canvas.width, context.canvas.height) / 42)
+  const alpha = options.inactive ? 0.45 : 1
+
+  context.save()
+  context.globalAlpha = alpha
+  context.shadowColor = 'rgba(0, 0, 0, 0.45)'
+  context.shadowBlur = radius * 0.7
+  context.fillStyle = options.color
+  context.strokeStyle = options.selected ? '#ffffff' : '#0f172a'
+  context.lineWidth = options.selected ? Math.max(3, radius / 4) : Math.max(2, radius / 5)
+  context.beginPath()
+  context.arc(x, y, radius, 0, Math.PI * 2)
+  context.fill()
+  context.stroke()
+
+  context.shadowBlur = 0
+  context.fillStyle = '#020617'
+  context.font = `900 ${Math.max(10, radius * 0.95)}px sans-serif`
+  context.textAlign = 'center'
+  context.textBaseline = 'middle'
+  context.fillText(options.label, x, y + 0.5)
+
+  const title = options.index ? `${options.index}. ${options.title}` : options.title
+  context.font = `700 ${Math.max(10, radius * 0.65)}px sans-serif`
+  const textWidth = context.measureText(title).width
+  const labelX = Math.min(Math.max(x, textWidth / 2 + 8), context.canvas.width - textWidth / 2 - 8)
+  const labelY = Math.max(radius + 14, y - radius - 10)
+  context.fillStyle = 'rgba(2, 6, 23, 0.82)'
+  roundRect(context, labelX - textWidth / 2 - 6, labelY - 8, textWidth + 12, 17, 5)
+  context.fill()
+  context.fillStyle = '#f8fafc'
+  context.textBaseline = 'middle'
+  context.fillText(title, labelX, labelY)
+  context.restore()
+}
+
+function roundRect(context: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, radius: number) {
+  context.beginPath()
+  context.moveTo(x + radius, y)
+  context.lineTo(x + width - radius, y)
+  context.quadraticCurveTo(x + width, y, x + width, y + radius)
+  context.lineTo(x + width, y + height - radius)
+  context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height)
+  context.lineTo(x + radius, y + height)
+  context.quadraticCurveTo(x, y + height, x, y + height - radius)
+  context.lineTo(x, y + radius)
+  context.quadraticCurveTo(x, y, x + radius, y)
+  context.closePath()
+}
+
+function mapToCanvas(map: RobotMapSnapshot, x: number, y: number) {
+  return {
+    x: (x - map.origin_x) / map.resolution,
+    y: map.height - (y - map.origin_y) / map.resolution,
+  }
+}
+
+function isOnMap(map: RobotMapSnapshot, point: { x: number; y: number }) {
+  return point.x >= 0 && point.x <= map.width && point.y >= 0 && point.y <= map.height
+}
+
+function occupancyColor(value: number): [number, number, number] {
+  if (value < 0) return [30, 41, 59]
+  if (value === 0) return [226, 232, 240]
+  const shade = Math.max(15, 210 - value * 1.8)
+  return [shade, shade, shade]
+}

--- a/frontend/health-robot-front/src/lib/robot-api.test.ts
+++ b/frontend/health-robot-front/src/lib/robot-api.test.ts
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { setAccessToken } from './api'
-import { commandRobotArm, fetchCurrentRobotMap, fetchRobotCameraSnapshot, loadSavedRobotMap, navigateToPosition, returnBase, saveCurrentRobotMap, sendTeleop, setPoseOrigin, uploadRobotSound } from './robot-api'
+import { commandRobotArm, createAnnotatedPoint, createMission, fetchAnnotatedPoints, fetchCurrentRobotMap, fetchRobotCameraSnapshot, fetchRobotScreenStatus, loadSavedRobotMap, navigateToPosition, returnBase, saveCurrentRobotMap, sendTeleop, setPoseOrigin, updateStockPointSupplies, uploadRobotSound } from './robot-api'
 
 const fetchMock = vi.fn()
 
@@ -127,5 +127,58 @@ describe('robot-api', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:4000/api/robot/arm')
     expect(init.method).toBe('POST')
     expect(JSON.parse(init.body as string)).toEqual({ joint1: 90, joint2: 60, joint3: 45, joint4: 90, joint5: 90, joint6: 90, time_ms: 1200 })
+  })
+
+  it('fetches annotated delivery points through backend', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    await fetchAnnotatedPoints({ type: 'DELIVERY_ROOM', active_only: true })
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:4000/api/annotated-points?type=DELIVERY_ROOM&active_only=true')
+  })
+
+  it('creates annotated points through backend', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'pt-1' }))
+
+    await createAnnotatedPoint({ name: 'Chambre 203', type: 'DELIVERY_ROOM', x: 3, y: 4, yaw: 0 })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:4000/api/annotated-points')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'Chambre 203', type: 'DELIVERY_ROOM', x: 3, y: 4, yaw: 0 })
+  })
+
+  it('updates stock supplies through backend', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    await updateStockPointSupplies('pt-1', [{ supply_type: 'gants', priority_order: 1 }])
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:4000/api/annotated-points/pt-1/supplies')
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(init.body as string)).toEqual({ supplies: [{ supply_type: 'gants', priority_order: 1 }] })
+  })
+
+  it('creates missions through backend', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'mis-1', status: 'NAVIGATING_TO_STOCK' }))
+
+    await createMission({ supply_type: 'gants', delivery_room_id: 'pt-room' })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:4000/api/missions')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ supply_type: 'gants', delivery_room_id: 'pt-room' })
+  })
+
+  it('fetches robot screen status with dedicated token only', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ robot_state: 'IDLE', screen_title_fr: 'CareBot' }))
+
+    await fetchRobotScreenStatus('screen-token')
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = init.headers as Record<string, string>
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:4000/api/robot-screen/status')
+    expect(headers['X-Robot-Screen-Token']).toBe('screen-token')
+    expect(headers.Authorization).toBeUndefined()
   })
 })

--- a/frontend/health-robot-front/src/lib/robot-api.ts
+++ b/frontend/health-robot-front/src/lib/robot-api.ts
@@ -109,6 +109,96 @@ export interface RobotArmState {
   joints: number[]
 }
 
+export type SupplyType = 'serviettes' | 'papier_toilette' | 'gants' | 'protections' | 'linge'
+export type AnnotatedPointType = 'STOCK' | 'DELIVERY_ROOM' | 'ROBOT_BASE'
+export type MissionStatus =
+  | 'PENDING'
+  | 'NAVIGATING_TO_STOCK'
+  | 'WAITING_FOR_RECOVERY_CONFIRMATION'
+  | 'NAVIGATING_TO_DELIVERY'
+  | 'WAITING_FOR_DELIVERY_CONFIRMATION'
+  | 'COMPLETED'
+  | 'CANCELLED'
+  | 'FAILED'
+
+export interface AnnotatedPoint {
+  id: string
+  name: string
+  type: AnnotatedPointType
+  x: number
+  y: number
+  yaw: number
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface AnnotatedPointPayload {
+  name: string
+  type: AnnotatedPointType
+  x: number
+  y: number
+  yaw: number
+  is_active?: boolean
+}
+
+export interface StockPointSupply {
+  stock_point_id: string
+  supply_type: SupplyType
+  priority_order: number
+  is_active: boolean
+}
+
+export interface StockPointSupplyPayload {
+  supply_type: SupplyType
+  priority_order: number
+  is_active?: boolean
+}
+
+export interface Mission {
+  id: string
+  status: MissionStatus
+  supply_type: SupplyType
+  delivery_room_id: string
+  delivery_room_name_snapshot: string
+  delivery_x_snapshot: number
+  delivery_y_snapshot: number
+  delivery_yaw_snapshot: number
+  stock_point_id: string
+  stock_point_name_snapshot: string
+  stock_x_snapshot: number
+  stock_y_snapshot: number
+  stock_yaw_snapshot: number
+  created_by_user_id: string
+  created_by_name_snapshot: string
+  created_at: string
+  started_at?: string | null
+  arrived_at_stock_at?: string | null
+  recovery_confirmed_at?: string | null
+  recovery_confirmed_by_user_id?: string | null
+  arrived_at_delivery_at?: string | null
+  delivery_confirmed_at?: string | null
+  delivery_confirmed_by_user_id?: string | null
+  completed_at?: string | null
+  cancelled_at?: string | null
+  cancelled_by_user_id?: string | null
+  failure_reason?: string | null
+  updated_at: string
+}
+
+export interface RobotScreenStatus {
+  robot_state: string
+  screen_title_fr: string
+  screen_message_fr: string
+  current_mission: {
+    id: string
+    status: MissionStatus
+    supply_label_fr: string
+    destination_label_fr: string
+  } | null
+  updated_at: string
+}
+
 export interface NavigatePayload {
   x: number
   y: number
@@ -221,6 +311,95 @@ export function resetEmergency() {
   return apiFetch<{ status: string }>('/api/safety/emergency/reset?actor=frontend', {
     method: 'POST',
   })
+}
+
+export function fetchAnnotatedPoints(params: { type?: AnnotatedPointType; active_only?: boolean } = {}) {
+  const search = new URLSearchParams()
+  if (params.type) search.set('type', params.type)
+  if (params.active_only !== undefined) search.set('active_only', String(params.active_only))
+  const query = search.toString()
+  return apiFetch<AnnotatedPoint[]>(`/api/annotated-points${query ? `?${query}` : ''}`)
+}
+
+export function createAnnotatedPoint(payload: AnnotatedPointPayload) {
+  return apiFetch<AnnotatedPoint>('/api/annotated-points', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+export function updateAnnotatedPoint(pointId: string, payload: Partial<AnnotatedPointPayload>) {
+  return apiFetch<AnnotatedPoint>(`/api/annotated-points/${encodeURIComponent(pointId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  })
+}
+
+export function deactivateAnnotatedPoint(pointId: string) {
+  return apiFetch<AnnotatedPoint>(`/api/annotated-points/${encodeURIComponent(pointId)}`, {
+    method: 'DELETE',
+  })
+}
+
+export function updateStockPointSupplies(pointId: string, supplies: StockPointSupplyPayload[]) {
+  return apiFetch<StockPointSupply[]>(`/api/annotated-points/${encodeURIComponent(pointId)}/supplies`, {
+    method: 'PUT',
+    body: JSON.stringify({ supplies }),
+  })
+}
+
+export function fetchStockPointSupplies(pointId: string) {
+  return apiFetch<StockPointSupply[]>(`/api/annotated-points/${encodeURIComponent(pointId)}/supplies`)
+}
+
+export function fetchMissions(params: { include_terminal?: boolean; limit?: number } = {}) {
+  const search = new URLSearchParams()
+  if (params.include_terminal !== undefined) search.set('include_terminal', String(params.include_terminal))
+  if (params.limit !== undefined) search.set('limit', String(params.limit))
+  const query = search.toString()
+  return apiFetch<Mission[]>(`/api/missions${query ? `?${query}` : ''}`)
+}
+
+export function createMission(payload: { supply_type: SupplyType; delivery_room_id: string }) {
+  return apiFetch<Mission>('/api/missions', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+export function confirmMissionRecovery(missionId: string) {
+  return apiFetch<Mission>(`/api/missions/${encodeURIComponent(missionId)}/confirm-recovery`, {
+    method: 'POST',
+  })
+}
+
+export function confirmMissionDelivery(missionId: string) {
+  return apiFetch<Mission>(`/api/missions/${encodeURIComponent(missionId)}/confirm-delivery`, {
+    method: 'POST',
+  })
+}
+
+export function cancelMission(missionId: string) {
+  return apiFetch<Mission>(`/api/missions/${encodeURIComponent(missionId)}/cancel`, {
+    method: 'POST',
+  })
+}
+
+export async function fetchRobotScreenStatus(token: string) {
+  const response = await fetch(resolveApiUrl('/api/robot-screen/status'), {
+    headers: {
+      Accept: 'application/json',
+      'X-Robot-Screen-Token': token,
+    },
+  })
+
+  if (!response.ok) {
+    const contentType = response.headers.get('content-type') ?? ''
+    const data = contentType.includes('application/json') ? await response.json().catch(() => undefined) : await response.text()
+    throw new ApiError(getRawErrorMessage(data, response.statusText || 'Erreur API'), response.status, data)
+  }
+
+  return response.json() as Promise<RobotScreenStatus>
 }
 
 export function fetchCurrentRobotMap() {

--- a/frontend/health-robot-front/src/routes/control.tsx
+++ b/frontend/health-robot-front/src/routes/control.tsx
@@ -1,23 +1,61 @@
 import { useEffect, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { AlertTriangle, Battery, Camera, Crosshair, Gauge, Loader2, MapPinned, Music2, OctagonX, Play, RefreshCw, Send, ShieldAlert, SlidersHorizontal, Trash2, Upload, Video, Wifi } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, Clock3, Loader2, MapPinned, OctagonX, PackageCheck, RefreshCw, RotateCcw, ShieldAlert, Truck } from 'lucide-react'
 
+import { MissionMapView } from '@/components/mission-map-view'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { useAuth } from '@/contexts/AuthContext'
-import { formatMapCoordinate, mapCoordinatesToPercent, mapMetadataToBounds, screenPointToMapCoordinates, type ControlMapBounds } from '@/lib/control-map'
-import { commandRobotArm, deleteRobotSound, fetchRobotArmState, fetchRobotCameraSnapshot, fetchRobotSounds, navigateToPosition, playRobotSound, resetEmergency, returnBase, triggerEmergencyStop, uploadRobotSound, type RobotMapMetadata, type RobotPose, type RobotSound } from '@/lib/robot-api'
-import { useRobot } from '@/lib/robot-context'
+import { ApiError } from '@/lib/api'
 import { canUseAdminControls, CAREGIVER_OR_ADMIN_ROLES } from '@/lib/permissions'
+import {
+  cancelMission,
+  confirmMissionDelivery,
+  confirmMissionRecovery,
+  createMission,
+  fetchAnnotatedPoints,
+  fetchCurrentRobotMap,
+  fetchMissions,
+  resetEmergency,
+  returnBase,
+  triggerEmergencyStop,
+  type AnnotatedPoint,
+  type Mission,
+  type MissionStatus,
+  type RobotMapSnapshot,
+  type SupplyType,
+} from '@/lib/robot-api'
+import { useRobot } from '@/lib/robot-context'
 import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/control')({ component: ControlRoute })
 
-const DEFAULT_ARM_JOINTS = [90, 90, 90, 90, 90, 90]
-const ARM_PRESETS = [
-  { name: 'Centre', joints: [90, 90, 90, 90, 90, 90] },
-  { name: 'Caméra avant', joints: [90, 60, 45, 90, 90, 90] },
-  { name: 'Caméra haut', joints: [90, 30, 60, 90, 90, 90] },
+const SUPPLY_OPTIONS: { value: SupplyType; label: string }[] = [
+  { value: 'serviettes', label: 'Serviettes' },
+  { value: 'papier_toilette', label: 'Papier toilette' },
+  { value: 'gants', label: 'Gants' },
+  { value: 'protections', label: 'Protections' },
+  { value: 'linge', label: 'Linge' },
 ]
+
+const ACTIVE_STATUSES: MissionStatus[] = [
+  'NAVIGATING_TO_STOCK',
+  'WAITING_FOR_RECOVERY_CONFIRMATION',
+  'NAVIGATING_TO_DELIVERY',
+  'WAITING_FOR_DELIVERY_CONFIRMATION',
+]
+
+const CANCELLABLE_STATUSES: MissionStatus[] = ['PENDING', ...ACTIVE_STATUSES]
+
+const STATUS_LABELS: Record<MissionStatus, string> = {
+  PENDING: 'En attente',
+  NAVIGATING_TO_STOCK: 'Vers le stock',
+  WAITING_FOR_RECOVERY_CONFIRMATION: 'Attente récupération',
+  NAVIGATING_TO_DELIVERY: 'Vers la chambre',
+  WAITING_FOR_DELIVERY_CONFIRMATION: 'Attente livraison',
+  COMPLETED: 'Terminée',
+  CANCELLED: 'Annulée',
+  FAILED: 'Échec',
+}
 
 function ControlRoute() {
   return (
@@ -29,67 +67,109 @@ function ControlRoute() {
 
 function ControlPage() {
   const { user } = useAuth()
-  const { telemetry, status, backendStatus, isStatusLoading, statusError, refreshStatus } = useRobot()
-  const [destination, setDestination] = useState({ x: '1.5', y: '2.3', yaw: '0', label: 'position libre' })
+  const { backendStatus, isStatusLoading, statusError, refreshStatus } = useRobot()
+  const [missions, setMissions] = useState<Mission[]>([])
+  const [deliveryRooms, setDeliveryRooms] = useState<AnnotatedPoint[]>([])
+  const [missionPoints, setMissionPoints] = useState<AnnotatedPoint[]>([])
+  const [currentMap, setCurrentMap] = useState<RobotMapSnapshot | null>(null)
+  const [selectedSupply, setSelectedSupply] = useState<SupplyType>('gants')
+  const [selectedDeliveryRoomId, setSelectedDeliveryRoomId] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isActionRunning, setIsActionRunning] = useState(false)
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const isAdmin = canUseAdminControls(user)
-  const canSubmitNavigate = isValidNumberInput(destination.x) && isValidNumberInput(destination.y) && isValidNumberInput(destination.yaw) && !isSubmitting
+
+  const activeMission = missions.find((mission) => ACTIVE_STATUSES.includes(mission.status)) ?? null
+  const queuedMissions = missions.filter((mission) => mission.status === 'PENDING')
   const statusRows = [
-    { label: 'mode', value: backendStatus?.mode ?? status },
-    { label: 'battery_level', value: backendStatus?.battery_level == null ? 'N/A' : `${backendStatus.battery_level}%` },
-    { label: 'battery_status', value: backendStatus?.battery_status ?? 'N/A' },
+    { label: 'mode', value: backendStatus?.mode ?? 'N/A' },
     { label: 'emergency_active', value: backendStatus?.emergency_active ? 'Actif' : 'Inactif' },
     { label: 'mission_id', value: backendStatus?.mission_id ?? 'Aucune' },
-    { label: 'eta_to_base_seconds', value: backendStatus?.eta_to_base_seconds == null ? 'N/A' : `${backendStatus.eta_to_base_seconds}s` },
-    { label: 'distance_remaining_m', value: backendStatus?.distance_remaining_m == null ? 'N/A' : `${backendStatus.distance_remaining_m}m` },
-    { label: 'current_speed_mps', value: formatSpeed(backendStatus?.current_speed_mps) },
-    { label: 'pose', value: formatPose(backendStatus?.pose) },
-    { label: 'map', value: formatMapMetadata(backendStatus?.map) },
-    { label: 'min_obstacle_distance_m', value: backendStatus?.min_obstacle_distance_m == null ? 'N/A' : `${backendStatus.min_obstacle_distance_m.toFixed(2)}m` },
+    { label: 'battery_level', value: backendStatus?.battery_level == null ? 'N/A' : `${backendStatus.battery_level}%` },
+    { label: 'pose', value: backendStatus?.pose ? `${backendStatus.pose.x.toFixed(2)}, ${backendStatus.pose.y.toFixed(2)}` : 'N/A' },
   ]
 
-  const runCommand = async (action: () => Promise<unknown>, successMessage: string) => {
-    setError('')
-    setMessage('')
-    setIsSubmitting(true)
+  const loadMissionData = async () => {
+    setIsLoading(true)
     try {
-      await action()
-      await refreshStatus()
-      setMessage(successMessage)
-    } catch (commandError) {
-      setError(commandError instanceof Error ? commandError.message : 'Commande refusée par le backend')
+      const [missionsResult, roomsResult, pointsResult, mapResult] = await Promise.allSettled([
+        fetchMissions({ include_terminal: false }),
+        fetchAnnotatedPoints({ type: 'DELIVERY_ROOM', active_only: true }),
+        fetchAnnotatedPoints({ active_only: true }),
+        fetchCurrentRobotMap(),
+      ])
+
+      if (missionsResult.status === 'rejected') throw missionsResult.reason
+      if (roomsResult.status === 'rejected') throw roomsResult.reason
+      if (pointsResult.status === 'rejected') throw pointsResult.reason
+
+      const nextMissions = missionsResult.value
+      const rooms = roomsResult.value
+      setMissions(nextMissions)
+      setDeliveryRooms(rooms)
+      setMissionPoints(pointsResult.value)
+      setSelectedDeliveryRoomId((previous) => previous || rooms[0]?.id || '')
+      if (mapResult.status === 'fulfilled') {
+        setCurrentMap(mapResult.value)
+      } else if (!(mapResult.reason instanceof ApiError && mapResult.reason.status === 404)) {
+        throw mapResult.reason
+      }
+      setError('')
+    } catch (loadError) {
+      setError(getErrorMessage(loadError))
     } finally {
-      setIsSubmitting(false)
+      setIsLoading(false)
     }
   }
 
-  const handleNavigate = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  useEffect(() => {
+    void loadMissionData()
+    const interval = window.setInterval(() => {
+      void loadMissionData()
+    }, 3000)
+    return () => window.clearInterval(interval)
+  }, [])
 
-    if (!canSubmitNavigate) {
-      setError('Destination invalide : renseigne x, y et yaw avec des valeurs numériques.')
+  const runAction = async (action: () => Promise<unknown>, successMessage: string) => {
+    setIsActionRunning(true)
+    setMessage('')
+    setError('')
+    try {
+      await action()
+      await Promise.all([loadMissionData(), refreshStatus()])
+      setMessage(successMessage)
+    } catch (actionError) {
+      setError(getErrorMessage(actionError))
+    } finally {
+      setIsActionRunning(false)
+    }
+  }
+
+  const submitMission = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedDeliveryRoomId) {
+      setError('Crée une chambre de livraison active dans /map avant de lancer une mission.')
       return
     }
-
-    await runCommand(
-      () =>
-        navigateToPosition({
-          x: Number(destination.x),
-          y: Number(destination.y),
-          yaw: Number(destination.yaw),
-          label: destination.label || 'position libre',
-        }),
-      'Navigation envoyée au backend',
+    await runAction(
+      () => createMission({ supply_type: selectedSupply, delivery_room_id: selectedDeliveryRoomId }),
+      'Mission créée. Le backend la démarre automatiquement si le robot est libre.',
     )
   }
 
   return (
     <div className="space-y-6 px-4 py-6 text-white sm:px-6 lg:px-8">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Contrôle du robot</h1>
-        <p className="text-sm text-slate-400">Commandes API FastAPI vers MQTT. Accès direct ROS2 depuis le frontend non disponible.</p>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200">Mission control</p>
+          <h1 className="mt-2 text-3xl font-black tracking-tight">Livraisons CareBot</h1>
+          <p className="mt-2 max-w-3xl text-sm text-slate-400">Le backend possède l'état mission, choisit le stock compatible et pilote les transitions jusqu'à la confirmation humaine.</p>
+        </div>
+        <button type="button" onClick={() => void loadMissionData()} disabled={isLoading} className="inline-flex items-center justify-center rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/10 disabled:opacity-60">
+          {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+          Actualiser
+        </button>
       </div>
 
       {backendStatus?.emergency_active && (
@@ -97,776 +177,232 @@ function ControlPage() {
           <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-rose-200" />
           <div>
             <p className="font-bold">Urgence active</p>
-            <p className="mt-1 text-rose-100/80">Le backend indique un arrêt d'urgence actif. Le reset est réservé aux administrateurs.</p>
+            <p className="mt-1 text-rose-100/80">Aucune navigation mission ne sera publiée tant que l'arrêt d'urgence est actif.</p>
           </div>
         </div>
       )}
 
-      {(message || error) && (
-        <div className={cn('rounded-3xl border p-4 text-sm', message && 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100', error && 'border-rose-400/30 bg-rose-400/10 text-rose-100')}>
-          {message || error}
+      {(message || error || statusError) && (
+        <div className={cn('rounded-3xl border p-4 text-sm', message && !error && !statusError && 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100', (error || statusError) && 'border-rose-400/30 bg-rose-400/10 text-rose-100')}>
+          {error || statusError || message}
         </div>
       )}
 
-      <div className="grid gap-4 lg:grid-cols-3">
-        <section className="space-y-4 lg:col-span-2">
-          <article className="sticky top-0 z-30 rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="text-lg font-semibold">Navigation libre</h2>
-            <p className="mt-2 text-sm text-slate-400">Disponible pour admin et caregiver via POST /api/robot/command/navigate.</p>
-
-            <div className="mt-5 grid gap-6 xl:grid-cols-[minmax(280px,0.95fr)_1fr]">
-              <RobotMapView
-                map={backendStatus?.map ?? null}
-                robotPose={backendStatus?.pose ?? null}
-                destinationX={destination.x}
-                destinationY={destination.y}
-                onSelect={(point) =>
-                  setDestination((previous) => ({
-                    ...previous,
-                    x: formatMapCoordinate(point.x),
-                    y: formatMapCoordinate(point.y),
-                    label: previous.label || 'position libre',
-                  }))
-                }
-              />
-
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+        <main className="space-y-4">
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
-                <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleNavigate}>
-                  <NumberField label="X" value={destination.x} onChange={(value) => setDestination((previous) => ({ ...previous, x: value }))} />
-                  <NumberField label="Y" value={destination.y} onChange={(value) => setDestination((previous) => ({ ...previous, y: value }))} />
-                  <NumberField label="Yaw" value={destination.yaw} onChange={(value) => setDestination((previous) => ({ ...previous, yaw: value }))} />
-                  <label className="space-y-2 text-sm">
-                    <span className="text-slate-300">Label</span>
-                    <input
-                      value={destination.label}
-                      onChange={(event) => setDestination((previous) => ({ ...previous, label: event.target.value }))}
-                      className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white"
-                    />
-                  </label>
-                  <div className="flex flex-wrap gap-3 sm:col-span-2">
-                    <button
-                      type="submit"
-                      disabled={!canSubmitNavigate}
-                      className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
-                      {isSubmitting ? 'Envoi...' : 'Envoyer navigation'}
-                    </button>
-                    <button
-                      type="button"
-                      disabled={!isAdmin || isSubmitting}
-                      onClick={() => void runCommand(returnBase, 'Retour à la base envoyé')}
-                      className="inline-flex items-center justify-center rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-5 py-3 text-sm font-bold text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      <MapPinned className="mr-2 h-4 w-4" /> Retour base
+                <h2 className="flex items-center gap-2 text-xl font-bold"><PackageCheck className="h-5 w-5 text-emerald-200" /> Créer une mission</h2>
+                <p className="mt-2 text-sm text-slate-400">Choisis une fourniture et une chambre active. Le stock est sélectionné automatiquement par le backend.</p>
+              </div>
+              <span className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1 text-xs font-bold text-cyan-100">FIFO</span>
+            </div>
+
+            <form className="mt-6 grid gap-4 md:grid-cols-[1fr_1fr_auto] md:items-end" onSubmit={submitMission}>
+              <label className="space-y-2 text-sm">
+                <span className="text-slate-300">Fourniture</span>
+                <select value={selectedSupply} onChange={(event) => setSelectedSupply(event.target.value as SupplyType)} className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white">
+                  {SUPPLY_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+              </label>
+              <label className="space-y-2 text-sm">
+                <span className="text-slate-300">Chambre</span>
+                <select value={selectedDeliveryRoomId} onChange={(event) => setSelectedDeliveryRoomId(event.target.value)} className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white">
+                  {deliveryRooms.length === 0 && <option value="">Aucune chambre active</option>}
+                  {deliveryRooms.map((room) => <option key={room.id} value={room.id}>{room.name}</option>)}
+                </select>
+              </label>
+              <button type="submit" disabled={isActionRunning || !selectedDeliveryRoomId} className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60">
+                {isActionRunning ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Truck className="mr-2 h-4 w-4" />}
+                Lancer
+              </button>
+            </form>
+          </section>
+
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="flex items-center gap-2 text-xl font-bold"><MapPinned className="h-5 w-5 text-cyan-200" /> Mission active</h2>
+            {activeMission ? (
+              <MissionCard mission={activeMission} isActionRunning={isActionRunning} onAction={runAction} />
+            ) : (
+              <div className="mt-5 rounded-3xl border border-dashed border-white/10 bg-slate-950/40 p-8 text-center text-slate-400">
+                <Clock3 className="mx-auto mb-3 h-10 w-10 text-slate-500" />
+                Aucune mission active. La prochaine mission en attente démarrera automatiquement si le robot est libre.
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="text-xl font-bold">File de missions</h2>
+            <div className="mt-5 space-y-3">
+              {queuedMissions.length === 0 && <p className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-center text-sm text-slate-400">Aucune mission en attente.</p>}
+              {queuedMissions.map((mission, index) => (
+                <div key={mission.id} className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">#{index + 1} · {formatSupplyLabel(mission.supply_type)} vers {mission.delivery_room_name_snapshot}</p>
+                      <p className="mt-1 text-xs text-slate-500">Créée par {mission.created_by_name_snapshot} · {formatDateTime(mission.created_at)}</p>
+                    </div>
+                    <button type="button" disabled={isActionRunning} onClick={() => void runAction(() => cancelMission(mission.id), 'Mission annulée')} className="rounded-xl border border-rose-400/20 bg-rose-400/10 px-3 py-2 text-xs font-bold text-rose-100 disabled:opacity-50">
+                      Annuler
                     </button>
                   </div>
-                </form>
-
-                <div className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-400/10 p-4 text-sm text-cyan-50">
-                  <p className="font-semibold">Carte ROS</p>
-                  <p className="mt-1 text-cyan-100/80">
-                    Les coordonnees viennent de la map publiee par le bridge ROS2/MQTT. Le bouton envoie ensuite la destination via le backend.
-                  </p>
                 </div>
-              </div>
+              ))}
             </div>
-
-            <div className="mt-6 rounded-3xl border border-rose-400/20 bg-rose-500/10 p-5 text-white shadow-lg shadow-rose-950/10">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h3 className="text-base font-semibold">Actions sécurité</h3>
-                  <p className="mt-1 text-sm text-rose-100/80">Emergency stop est disponible pour admin et caregiver.</p>
-                </div>
-                {isStatusLoading && <Loader2 className="h-4 w-4 animate-spin text-cyan-200" />}
-              </div>
-              <div className="mt-5 flex flex-wrap gap-3">
-                <button
-                  type="button"
-                  disabled={isSubmitting}
-                  onClick={() => void runCommand(() => triggerEmergencyStop('manual_ui_stop'), 'Emergency stop envoyé')}
-                  className="inline-flex items-center justify-center rounded-2xl bg-rose-500 px-6 py-4 text-base font-bold text-white shadow-lg transition hover:bg-rose-400 active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <OctagonX className="mr-2 h-6 w-6" /> EMERGENCY STOP
-                </button>
-
-                {isAdmin && (
-                  <button
-                    type="button"
-                    disabled={isSubmitting}
-                    onClick={() => void runCommand(resetEmergency, 'Emergency reset envoyé')}
-                    className="inline-flex items-center justify-center rounded-2xl border border-amber-400/30 bg-amber-400/10 px-5 py-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/20 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <ShieldAlert className="mr-2 h-4 w-4" /> Reset emergency
-                  </button>
-                )}
-              </div>
-
-              {!isAdmin && (
-                <p className="mt-4 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-3 text-sm text-amber-100">
-                  Reset emergency est réservé aux administrateurs.
-                </p>
-              )}
-            </div>
-          </article>
-        </section>
+          </section>
+        </main>
 
         <aside className="space-y-4">
-          <CameraFeed />
+          <section className="rounded-3xl border border-rose-400/20 bg-rose-500/10 p-6 shadow-lg shadow-rose-950/10">
+            <h2 className="text-lg font-bold">Sécurité</h2>
+            <p className="mt-2 text-sm text-rose-100/80">Emergency stop reste disponible aux aides-soignants et admins.</p>
+            <div className="mt-5 space-y-3">
+              <button type="button" disabled={isActionRunning} onClick={() => void runAction(() => triggerEmergencyStop('manual_ui_stop'), 'Emergency stop envoyé')} className="inline-flex w-full items-center justify-center rounded-2xl bg-rose-500 px-5 py-4 text-base font-black text-white shadow-lg transition hover:bg-rose-400 disabled:opacity-60">
+                <OctagonX className="mr-2 h-6 w-6" /> EMERGENCY STOP
+              </button>
+              {isAdmin && (
+                <button type="button" disabled={isActionRunning} onClick={() => void runAction(resetEmergency, 'Emergency reset envoyé')} className="inline-flex w-full items-center justify-center rounded-2xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm font-bold text-amber-100 transition hover:bg-amber-400/20 disabled:opacity-60">
+                  <ShieldAlert className="mr-2 h-4 w-4" /> Reset emergency
+                </button>
+              )}
+              {isAdmin && (
+                <button type="button" disabled={isActionRunning || Boolean(activeMission)} onClick={() => void runAction(returnBase, 'Retour base envoyé')} className="inline-flex w-full items-center justify-center rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-3 text-sm font-bold text-emerald-100 transition hover:bg-emerald-400/20 disabled:opacity-60">
+                  <RotateCcw className="mr-2 h-4 w-4" /> Retour base explicite
+                </button>
+              )}
+            </div>
+          </section>
 
-          <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-base font-semibold">Robot Status</h2>
+                <h2 className="text-lg font-bold">Robot status</h2>
                 <p className="mt-1 text-xs text-slate-400">GET /api/robot/status</p>
               </div>
               {isStatusLoading && <Loader2 className="h-4 w-4 animate-spin text-cyan-200" />}
             </div>
-
-            {statusError && (
-              <div className="mt-4 rounded-2xl border border-rose-400/30 bg-rose-400/10 p-3 text-sm text-rose-100">
-                {statusError}
-              </div>
-            )}
-
             <div className="mt-5 space-y-3">
-              {statusRows.map((row) => (
-                <StatusRow key={row.label} label={row.label} value={row.value} danger={row.label === 'emergency_active' && row.value === 'Actif'} />
-              ))}
+              {statusRows.map((row) => <StatusRow key={row.label} label={row.label} value={row.value} danger={row.label === 'emergency_active' && row.value === 'Actif'} />)}
             </div>
-          </article>
+          </section>
 
-          <RobotArmPanel isAdmin={isAdmin} />
-          <RobotSoundsPanel isAdmin={isAdmin} />
-
-          <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="text-base font-semibold">Cache télémétrie local</h2>
-            <div className="mt-5 space-y-4">
-              <MetricRow icon={Gauge} label="Speed" value={`${telemetry.speed.toFixed(2)} m/s`} />
-              <MetricRow icon={Battery} label="Battery" value={`${Math.round(telemetry.battery)}%`} />
-              <MetricRow icon={Wifi} label="État du backend" value={`${Math.round(telemetry.connectionQuality)}%`} />
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="flex items-center gap-2 text-lg font-bold"><MapPinned className="h-5 w-5 text-cyan-200" /> Points mission</h2>
+            <p className="mt-2 text-sm text-slate-400">Carte opérationnelle interne: points configurés dans `/map`, robot, stock sélectionné et chambre de livraison.</p>
+            <div className="mt-5 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/80 p-2">
+              <MissionMapView
+                map={currentMap}
+                pose={backendStatus?.pose ?? null}
+                points={missionPoints}
+                activeMission={activeMission}
+                selectedPointId={selectedDeliveryRoomId}
+                className="max-h-[360px]"
+              />
             </div>
-          </article>
-
-          <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="text-base font-semibold">État actuel</h2>
-            <div className={cn('mt-4 rounded-2xl p-4 text-center', status === 'idle' && 'bg-white/5', status === 'moving' && 'bg-cyan-400/10', status === 'charging' && 'bg-amber-400/10', status === 'delivering' && 'bg-emerald-400/10')}>
-              <p className={cn('text-2xl font-bold capitalize', status === 'idle' && 'text-slate-300', status === 'moving' && 'text-cyan-200', status === 'charging' && 'text-amber-200', status === 'delivering' && 'text-emerald-200')}>
-                {backendStatus?.mode ?? status}
-              </p>
-              <p className="mt-1 text-sm text-slate-400">{backendStatus?.battery_status ?? 'Interrogation du backend'}</p>
+            <div className="mt-4 grid gap-2 text-xs text-slate-300">
+              <LegendDot color="bg-emerald-300" label="Stock" />
+              <LegendDot color="bg-sky-300" label="Chambre" />
+              <LegendDot color="bg-amber-300" label="Base robot" />
             </div>
-          </article>
+          </section>
         </aside>
       </div>
     </div>
   )
 }
 
-function CameraFeed() {
-  const [imageUrl, setImageUrl] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState('')
-
-  const loadSnapshot = async () => {
-    setError('')
-    setIsLoading(true)
-    try {
-      const blob = await fetchRobotCameraSnapshot()
-      setImageUrl(URL.createObjectURL(blob))
-    } catch (cameraError) {
-      setError(cameraError instanceof Error ? cameraError.message : 'Camera robot indisponible')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    void loadSnapshot()
-  }, [])
-
-  useEffect(() => {
-    return () => {
-      if (imageUrl) {
-        URL.revokeObjectURL(imageUrl)
-      }
-    }
-  }, [imageUrl])
-
+function MissionCard({ mission, isActionRunning, onAction }: { mission: Mission; isActionRunning: boolean; onAction: (action: () => Promise<unknown>, successMessage: string) => Promise<void> }) {
   return (
-    <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className="mt-5 rounded-3xl border border-cyan-400/20 bg-cyan-400/10 p-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h2 className="flex items-center gap-2 text-lg font-semibold">
-            <Video className="h-5 w-5" /> Camera Feed
-          </h2>
-          <p className="mt-2 text-sm text-slate-400">JPEG proxifie via GET /api/robot/camera/snapshot avec JWT backend.</p>
+          <span className={cn('rounded-full px-3 py-1 text-xs font-bold', statusClass(mission.status))}>{STATUS_LABELS[mission.status]}</span>
+          <h3 className="mt-4 text-2xl font-black text-white">{formatSupplyLabel(mission.supply_type)} vers {mission.delivery_room_name_snapshot}</h3>
+          <p className="mt-2 text-sm text-cyan-50/80">Stock sélectionné: {mission.stock_point_name_snapshot}</p>
+          <p className="mt-1 font-mono text-xs text-cyan-100/70">{mission.id}</p>
         </div>
-        <button
-          type="button"
-          onClick={() => void loadSnapshot()}
-          disabled={isLoading}
-          className="inline-flex items-center rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
-          Refresh
-        </button>
-      </div>
-
-      {error && <div className="mt-4 rounded-2xl border border-rose-400/30 bg-rose-400/10 p-3 text-sm text-rose-100">{error}</div>}
-
-      <div className="relative mt-4 flex aspect-video items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-slate-950/70">
-        {imageUrl ? (
-          <img src={imageUrl} alt="Flux camera robot" className="h-full w-full object-contain" />
-        ) : (
-          <div className="text-center text-slate-400">
-            <Camera className="mx-auto mb-3 h-16 w-16 text-slate-500/60" />
-            <p>{isLoading ? 'Chargement camera...' : 'Snapshot camera en attente'}</p>
-            <p className="mt-1 text-xs text-slate-500">Le frontend ne se connecte pas directement au robot.</p>
-          </div>
-        )}
-
-        {isLoading && imageUrl && (
-          <div className="absolute inset-0 flex items-center justify-center bg-slate-950/45 text-sm text-cyan-100 backdrop-blur-sm">
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Mise a jour camera
-          </div>
-        )}
-      </div>
-    </article>
-  )
-}
-
-function RobotArmPanel({ isAdmin }: { isAdmin: boolean }) {
-  const [joints, setJoints] = useState(DEFAULT_ARM_JOINTS)
-  const [timeMs, setTimeMs] = useState('800')
-  const [isLoading, setIsLoading] = useState(false)
-  const [isSending, setIsSending] = useState(false)
-  const [message, setMessage] = useState('')
-  const [error, setError] = useState('')
-
-  const loadArmState = async () => {
-    setError('')
-    setIsLoading(true)
-    try {
-      const state = await fetchRobotArmState()
-      setJoints(normalizeArmJoints(state.joints))
-    } catch (armError) {
-      setError(armError instanceof Error ? armError.message : 'Etat bras indisponible')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    void loadArmState()
-  }, [])
-
-  const sendArmCommand = async () => {
-    if (!isAdmin) {
-      return
-    }
-
-    const duration = Math.round(Number(timeMs))
-    if (!Number.isFinite(duration) || duration < 100 || duration > 5000) {
-      setError('time_ms doit etre compris entre 100 et 5000.')
-      return
-    }
-
-    setError('')
-    setMessage('')
-    setIsSending(true)
-    try {
-      const state = await commandRobotArm(joints, duration)
-      setJoints(normalizeArmJoints(state.joints))
-      setMessage('Commande bras envoyee')
-    } catch (armError) {
-      setError(armError instanceof Error ? armError.message : 'Commande bras refusee')
-    } finally {
-      setIsSending(false)
-    }
-  }
-
-  return (
-    <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="flex items-center gap-2 text-lg font-semibold">
-            <SlidersHorizontal className="h-5 w-5" /> Bras robot
-          </h2>
-          <p className="mt-2 text-sm text-slate-400">Lecture pour admin/caregiver, commande reservee admin via POST /api/robot/arm.</p>
+        <div className="rounded-2xl border border-white/10 bg-slate-950/40 px-4 py-3 text-right text-xs text-slate-300">
+          <p>Créée: {formatDateTime(mission.created_at)}</p>
+          {mission.started_at && <p className="mt-1">Démarrée: {formatDateTime(mission.started_at)}</p>}
         </div>
-        <button
-          type="button"
-          onClick={() => void loadArmState()}
-          disabled={isLoading}
-          className="inline-flex items-center rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
-          Etat
-        </button>
       </div>
 
-      {(message || error) && (
-        <div className={cn('mt-4 rounded-2xl border p-3 text-sm', message && 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100', error && 'border-rose-400/30 bg-rose-400/10 text-rose-100')}>
-          {message || error}
-        </div>
-      )}
-
-      <div className="mt-5 grid gap-4 md:grid-cols-2">
-        {joints.map((joint, index) => (
-          <label key={index} className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-sm">
-            <span className="flex items-center justify-between gap-3 text-slate-300">
-              <span>Joint {index + 1}</span>
-              <span className="font-mono text-white">{joint} deg</span>
-            </span>
-            <input
-              type="range"
-              min="0"
-              max="180"
-              value={joint}
-              disabled={!isAdmin || isSending}
-              onChange={(event) => setJoints((previous) => previous.map((value, jointIndex) => (jointIndex === index ? Number(event.target.value) : value)))}
-              className="mt-3 w-full accent-cyan-300 disabled:opacity-50"
-            />
-          </label>
-        ))}
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        <RoutePoint title="1. Stock" name={mission.stock_point_name_snapshot} x={mission.stock_x_snapshot} y={mission.stock_y_snapshot} reached={Boolean(mission.arrived_at_stock_at)} />
+        <RoutePoint title="2. Chambre" name={mission.delivery_room_name_snapshot} x={mission.delivery_x_snapshot} y={mission.delivery_y_snapshot} reached={Boolean(mission.arrived_at_delivery_at)} />
       </div>
 
-      <div className="mt-5 flex flex-wrap items-end gap-3">
-        {ARM_PRESETS.map((preset) => (
-          <button
-            key={preset.name}
-            type="button"
-            disabled={!isAdmin || isSending}
-            onClick={() => setJoints([...preset.joints])}
-            className="rounded-2xl border border-cyan-400/20 bg-cyan-400/10 px-4 py-2 text-sm font-medium text-cyan-50 transition hover:bg-cyan-400/20 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {preset.name}
+      <div className="mt-5 flex flex-wrap gap-3">
+        {mission.status === 'WAITING_FOR_RECOVERY_CONFIRMATION' && (
+          <button type="button" disabled={isActionRunning} onClick={() => void onAction(() => confirmMissionRecovery(mission.id), 'Récupération confirmée. Navigation vers la chambre publiée.')} className="inline-flex items-center rounded-2xl bg-emerald-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-emerald-300 disabled:opacity-60">
+            <CheckCircle2 className="mr-2 h-4 w-4" /> Confirmer récupération
           </button>
-        ))}
-
-        <label className="space-y-2 text-sm">
-          <span className="text-slate-300">time_ms</span>
-          <input
-            type="number"
-            min="100"
-            max="5000"
-            step="100"
-            value={timeMs}
-            disabled={!isAdmin || isSending}
-            onChange={(event) => setTimeMs(event.target.value)}
-            className="w-28 rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-2 text-white disabled:opacity-50"
-          />
-        </label>
-
-        <button
-          type="button"
-          disabled={!isAdmin || isSending}
-          onClick={() => void sendArmCommand()}
-          className="inline-flex items-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isSending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
-          Envoyer bras
-        </button>
-      </div>
-
-      {!isAdmin && <p className="mt-4 rounded-2xl border border-amber-400/20 bg-amber-400/10 p-3 text-sm text-amber-100">Les commandes bras et presets sont réservés aux administrateurs.</p>}
-    </article>
-  )
-}
-
-function RobotSoundsPanel({ isAdmin }: { isAdmin: boolean }) {
-  const [sounds, setSounds] = useState<RobotSound[]>([])
-  const [selectedFile, setSelectedFile] = useState<File | null>(null)
-  const [uploadName, setUploadName] = useState('')
-  const [fileInputKey, setFileInputKey] = useState(0)
-  const [isLoading, setIsLoading] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [message, setMessage] = useState('')
-  const [error, setError] = useState('')
-
-  const loadSounds = async () => {
-    setError('')
-    setIsLoading(true)
-    try {
-      const response = await fetchRobotSounds()
-      setSounds(response.sounds)
-    } catch (soundError) {
-      setError(soundError instanceof Error ? soundError.message : 'Sons robot indisponibles')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    void loadSounds()
-  }, [])
-
-  const runSoundAction = async (action: () => Promise<unknown>, successMessage: string, refreshAfter = true) => {
-    setError('')
-    setMessage('')
-    setIsSubmitting(true)
-    try {
-      await action()
-      if (refreshAfter) {
-        await loadSounds()
-      }
-      setMessage(successMessage)
-    } catch (soundError) {
-      setError(soundError instanceof Error ? soundError.message : 'Operation audio refusee')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleUpload = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!isAdmin) {
-      return
-    }
-    if (!selectedFile) {
-      setError('Choisis un fichier audio a uploader.')
-      return
-    }
-
-    const name = uploadName.trim() || selectedFile.name
-    await runSoundAction(() => uploadRobotSound(name, selectedFile), `Son uploade: ${name}`)
-    setSelectedFile(null)
-    setUploadName('')
-    setFileInputKey((value) => value + 1)
-  }
-
-  return (
-    <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="flex items-center gap-2 text-lg font-semibold">
-            <Music2 className="h-5 w-5" /> Audio robot
-          </h2>
-          <p className="mt-2 text-sm text-slate-400">Liste et lecture pour admin/caregiver. Upload/delete reserves admin.</p>
-        </div>
-        <button
-          type="button"
-          onClick={() => void loadSounds()}
-          disabled={isLoading}
-          className="inline-flex items-center rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
-          Refresh
-        </button>
-      </div>
-
-      {(message || error) && (
-        <div className={cn('mt-4 rounded-2xl border p-3 text-sm', message && 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100', error && 'border-rose-400/30 bg-rose-400/10 text-rose-100')}>
-          {message || error}
-        </div>
-      )}
-
-      {isAdmin && (
-        <form className="mt-5 grid gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4 md:grid-cols-[1fr_1fr_auto]" onSubmit={handleUpload}>
-          <label className="space-y-2 text-sm">
-            <span className="text-slate-300">Fichier audio</span>
-            <input
-              key={fileInputKey}
-              type="file"
-              accept="audio/*"
-              onChange={(event) => {
-                const file = event.currentTarget.files?.[0] ?? null
-                setSelectedFile(file)
-                setUploadName(file?.name ?? '')
-              }}
-              className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white file:mr-3 file:rounded-xl file:border-0 file:bg-cyan-400 file:px-3 file:py-2 file:text-sm file:font-bold file:text-slate-950"
-            />
-          </label>
-          <label className="space-y-2 text-sm">
-            <span className="text-slate-300">Nom sur le robot</span>
-            <input
-              value={uploadName}
-              onChange={(event) => setUploadName(event.target.value)}
-              placeholder="message.mp3"
-              className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white"
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={isSubmitting || !selectedFile}
-            className="inline-flex items-center justify-center self-end rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
-            Upload
+        )}
+        {mission.status === 'WAITING_FOR_DELIVERY_CONFIRMATION' && (
+          <button type="button" disabled={isActionRunning} onClick={() => void onAction(() => confirmMissionDelivery(mission.id), 'Livraison confirmée. Mission terminée.')} className="inline-flex items-center rounded-2xl bg-emerald-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-emerald-300 disabled:opacity-60">
+            <CheckCircle2 className="mr-2 h-4 w-4" /> Confirmer livraison
           </button>
-        </form>
-      )}
-
-      {!isAdmin && <p className="mt-5 rounded-2xl border border-amber-400/20 bg-amber-400/10 p-3 text-sm text-amber-100">Upload et suppression audio sont réservés aux administrateurs.</p>}
-
-      <div className="mt-5 space-y-3">
-        {sounds.length === 0 && !isLoading && <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-sm text-slate-400">Aucun son disponible dans /root/sounds.</div>}
-        {sounds.map((sound) => (
-          <div key={sound.name} className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4">
-            <div>
-              <p className="font-medium text-white">{sound.name}</p>
-              <p className="mt-1 font-mono text-xs text-slate-400">{formatBytes(sound.size)}</p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <button
-                type="button"
-                disabled={isSubmitting}
-                onClick={() => void runSoundAction(() => playRobotSound(sound.name), `Lecture demandee: ${sound.name}`, false)}
-                className="inline-flex items-center rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-4 py-2 text-sm font-medium text-emerald-50 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <Play className="mr-2 h-4 w-4" /> Play
-              </button>
-              {isAdmin && (
-                <button
-                  type="button"
-                  disabled={isSubmitting}
-                  onClick={() => void runSoundAction(() => deleteRobotSound(sound.name), `Son supprime: ${sound.name}`)}
-                  className="inline-flex items-center rounded-2xl border border-rose-400/20 bg-rose-400/10 px-4 py-2 text-sm font-medium text-rose-50 transition hover:bg-rose-400/20 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" /> Delete
-                </button>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-    </article>
-  )
-}
-
-function RobotMapView({
-  map,
-  robotPose,
-  destinationX,
-  destinationY,
-  onSelect,
-}: {
-  map: RobotMapMetadata | null
-  robotPose: RobotPose | null
-  destinationX: string
-  destinationY: string
-  onSelect: (point: { x: number; y: number }) => void
-}) {
-  if (!map) {
-    return (
-      <div className="space-y-3">
-        <div className="flex items-center justify-between gap-3 text-sm">
-          <span className="inline-flex items-center gap-2 font-semibold text-white">
-            <MapPinned className="h-4 w-4 text-cyan-200" /> Map ROS
-          </span>
-          <span className="font-mono text-xs text-amber-200">en attente MQTT</span>
-        </div>
-        <div className="flex aspect-[1.25] items-center justify-center rounded-3xl border border-amber-400/20 bg-slate-950/80 p-6 text-center text-sm text-slate-300">
-          <div>
-            <MapPinned className="mx-auto mb-3 h-10 w-10 text-amber-200/70" />
-            <p className="font-semibold text-white">Map ROS non encore recue</p>
-            <p className="mt-2 text-slate-400">Le bridge doit publier `/map` vers MQTT avant de choisir une destination sur la carte.</p>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  const bounds = mapMetadataToBounds(map)
-  const x = Number(destinationX)
-  const y = Number(destinationY)
-  const hasDestination = Number.isFinite(x) && Number.isFinite(y) && isInsideBounds(x, y, bounds)
-  const destinationMarker = hasDestination ? mapCoordinatesToPercent(x, y, bounds) : null
-  const robotMarker = robotPose && isInsideBounds(robotPose.x, robotPose.y, bounds) ? mapCoordinatesToPercent(robotPose.x, robotPose.y, bounds) : null
-  const verticalTicks = buildMapTicks(bounds.minX, bounds.maxX)
-  const horizontalTicks = buildMapTicks(bounds.minY, bounds.maxY)
-  const widthMeters = map.width * map.resolution
-  const heightMeters = map.height * map.resolution
-
-  const selectFromEvent = (event: React.MouseEvent<HTMLDivElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect()
-    onSelect(screenPointToMapCoordinates(event.clientX, event.clientY, rect, bounds))
-  }
-
-  const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    selectFromEvent(event)
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-3 text-sm">
-        <span className="inline-flex items-center gap-2 font-semibold text-white">
-          <MapPinned className="h-4 w-4 text-cyan-200" /> Map ROS
-        </span>
-        <span className="font-mono text-xs text-slate-400">
-          {map.width}x{map.height} @ {map.resolution.toFixed(2)}m
-        </span>
-      </div>
-      <div
-        role="button"
-        tabIndex={0}
-        aria-label="Choisir une destination sur la map ROS"
-        onClick={selectFromEvent}
-        onContextMenu={handleContextMenu}
-        className="relative overflow-hidden rounded-3xl border border-cyan-400/30 bg-[#05070b] shadow-inner shadow-cyan-950/40 cursor-crosshair outline-none transition focus:ring-2 focus:ring-cyan-300"
-        style={{ aspectRatio: `${Math.max(map.width, 1)} / ${Math.max(map.height, 1)}` }}
-      >
-        <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="absolute inset-0 h-full w-full text-slate-700" aria-hidden="true">
-          <defs>
-            <radialGradient id="robotMapGlow" cx="50%" cy="50%" r="70%">
-              <stop offset="0%" stopColor="rgba(34,211,238,0.13)" />
-              <stop offset="100%" stopColor="rgba(15,23,42,0)" />
-            </radialGradient>
-          </defs>
-          <rect width="100" height="100" fill="url(#robotMapGlow)" />
-          {verticalTicks.map((tick) => {
-            const left = mapCoordinatesToPercent(tick, bounds.minY, bounds).left
-            return <line key={`x-${tick}`} x1={left} x2={left} y1="0" y2="100" stroke="currentColor" strokeWidth="0.22" />
-          })}
-          {horizontalTicks.map((tick) => {
-            const top = mapCoordinatesToPercent(bounds.minX, tick, bounds).top
-            return <line key={`y-${tick}`} x1="0" x2="100" y1={top} y2={top} stroke="currentColor" strokeWidth="0.22" />
-          })}
-          {bounds.minX <= 0 && bounds.maxX >= 0 && (
-            <line x1={mapCoordinatesToPercent(0, bounds.minY, bounds).left} x2={mapCoordinatesToPercent(0, bounds.minY, bounds).left} y1="0" y2="100" stroke="currentColor" strokeWidth="0.55" className="text-cyan-300/60" />
-          )}
-          {bounds.minY <= 0 && bounds.maxY >= 0 && (
-            <line x1="0" x2="100" y1={mapCoordinatesToPercent(bounds.minX, 0, bounds).top} y2={mapCoordinatesToPercent(bounds.minX, 0, bounds).top} stroke="currentColor" strokeWidth="0.55" className="text-cyan-300/60" />
-          )}
-          <text x="97" y="48" textAnchor="end" className="fill-cyan-100 text-[4px] font-bold">+X</text>
-          <text x="52" y="7" className="fill-cyan-100 text-[4px] font-bold">+Y</text>
-        </svg>
-
-        <div className="absolute left-3 top-3 rounded-2xl border border-white/10 bg-slate-950/80 px-3 py-2 font-mono text-[11px] text-slate-300 backdrop-blur">
-          {bounds.minX.toFixed(2)}..{bounds.maxX.toFixed(2)}m / {bounds.minY.toFixed(2)}..{bounds.maxY.toFixed(2)}m
-        </div>
-
-        {robotMarker && (
-          <div
-            className="absolute h-6 w-6 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-emerald-100 bg-emerald-400 shadow-lg shadow-emerald-500/40"
-            style={{ left: `${robotMarker.left}%`, top: `${robotMarker.top}%` }}
-            title="Position robot"
-          >
-            <span
-              className="absolute left-1/2 top-1/2 h-1.5 w-5 origin-left rounded-full bg-emerald-100"
-              style={{ transform: `translateY(-50%) rotate(${robotPose?.yaw ?? 0}rad)` }}
-            />
-          </div>
         )}
-
-        {destinationMarker && (
-          <div
-            className="absolute h-7 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-amber-300 shadow-lg shadow-amber-500/40"
-            style={{ left: `${destinationMarker.left}%`, top: `${destinationMarker.top}%` }}
-            title="Destination selectionnee"
-          >
-            <span className="absolute inset-[-9px] rounded-full border border-amber-300/60" />
-          </div>
+        {CANCELLABLE_STATUSES.includes(mission.status) && (
+          <button type="button" disabled={isActionRunning} onClick={() => void onAction(() => cancelMission(mission.id), 'Mission annulée')} className="inline-flex items-center rounded-2xl border border-rose-400/30 bg-rose-400/10 px-5 py-3 text-sm font-bold text-rose-100 transition hover:bg-rose-400/20 disabled:opacity-60">
+            Annuler mission
+          </button>
         )}
-      </div>
-      <div className="grid gap-2 text-xs text-slate-400 sm:grid-cols-2">
-        <p><Crosshair className="mr-1 inline h-3.5 w-3.5 text-cyan-200" /> Clic ou clic droit = placer un pin, comme le dashboard M3 Pro.</p>
-        <p>Dimensions reelles: {widthMeters.toFixed(2)}m x {heightMeters.toFixed(2)}m. Envoi final via backend securise.</p>
       </div>
     </div>
   )
 }
 
-function NumberField({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+function RoutePoint({ title, name, x, y, reached }: { title: string; name: string; x: number; y: number; reached: boolean }) {
   return (
-    <label className="space-y-2 text-sm">
-      <span className="text-slate-300">{label}</span>
-      <input
-        type="number"
-        step="0.1"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white"
-      />
-    </label>
-  )
-}
-
-function MetricRow({ icon: Icon, label, value }: { icon: typeof Gauge; label: string; value: string }) {
-  return (
-    <div className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-slate-950/40 p-3 text-sm">
-      <span className="inline-flex items-center gap-2 text-slate-300">
-        <Icon className="h-4 w-4 text-cyan-200" /> {label}
-      </span>
-      <span className="font-mono text-white">{value}</span>
+    <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">{title}</p>
+          <p className="mt-2 font-semibold text-white">{name}</p>
+          <p className="mt-1 font-mono text-xs text-slate-500">{x.toFixed(2)}, {y.toFixed(2)}</p>
+        </div>
+        {reached && <CheckCircle2 className="h-5 w-5 text-emerald-200" />}
+      </div>
     </div>
   )
 }
 
 function StatusRow({ label, value, danger = false }: { label: string; value: string; danger?: boolean }) {
   return (
-    <div className={cn('flex items-center justify-between gap-4 rounded-2xl border px-3 py-2 text-sm', danger ? 'border-rose-400/30 bg-rose-400/10' : 'border-white/10 bg-slate-950/40')}>
-      <span className="font-mono text-xs text-slate-400">{label}</span>
-      <span className={cn('text-right font-medium', danger ? 'text-rose-100' : 'text-white')}>{value}</span>
+    <div className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-slate-950/40 px-3 py-2">
+      <span className="text-xs text-slate-400">{label}</span>
+      <span className={cn('font-mono text-sm text-white', danger && 'font-bold text-rose-200')}>{value}</span>
     </div>
   )
 }
 
-function formatPose(pose: RobotPose | null | undefined) {
-  if (!pose) return 'N/A'
-  const yaw = pose.yaw == null ? '' : ` / yaw ${pose.yaw.toFixed(2)}`
-  return `${pose.x.toFixed(2)}, ${pose.y.toFixed(2)}${yaw}`
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className={cn('h-2.5 w-2.5 rounded-full', color)} />
+      <span>{label}</span>
+    </div>
+  )
 }
 
-function formatMapMetadata(map: RobotMapMetadata | null | undefined) {
-  if (!map) return 'N/A'
-  return `${map.width}x${map.height} @ ${map.resolution.toFixed(2)}m`
+function formatSupplyLabel(value: SupplyType) {
+  return SUPPLY_OPTIONS.find((option) => option.value === value)?.label ?? value
 }
 
-function formatSpeed(speed: number | null | undefined) {
-  if (speed == null || Math.abs(speed) < 0.001) return '0.00 m/s'
-  return `${speed.toFixed(2)} m/s`
+function formatDateTime(value: string) {
+  return new Date(value).toLocaleString()
 }
 
-function isInsideBounds(x: number, y: number, bounds: ControlMapBounds) {
-  return x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY
+function statusClass(status: MissionStatus) {
+  if (status === 'PENDING') return 'bg-slate-400/10 text-slate-200'
+  if (status.includes('WAITING')) return 'bg-amber-400/10 text-amber-100'
+  if (status.includes('NAVIGATING')) return 'bg-cyan-400/10 text-cyan-100'
+  if (status === 'COMPLETED') return 'bg-emerald-400/10 text-emerald-100'
+  return 'bg-rose-400/10 text-rose-100'
 }
 
-function buildMapTicks(min: number, max: number) {
-  const start = Math.ceil(min)
-  const end = Math.floor(max)
-  const span = end - start
-  const step = span > 24 ? Math.ceil(span / 24) : 1
-  const ticks: number[] = []
-
-  for (let value = start; value <= end; value += step) {
-    ticks.push(value)
-  }
-
-  return ticks
-}
-
-function isValidNumberInput(value: string) {
-  return value.trim().length > 0 && Number.isFinite(Number(value))
-}
-
-function normalizeArmJoints(joints: number[]) {
-  return DEFAULT_ARM_JOINTS.map((fallback, index) => {
-    const value = Number(joints[index])
-    if (!Number.isFinite(value)) {
-      return fallback
-    }
-    return Math.max(0, Math.min(180, Math.round(value)))
-  })
-}
-
-function formatBytes(size: number) {
-  if (!Number.isFinite(size) || size <= 0) {
-    return '0 B'
-  }
-  if (size < 1024) {
-    return `${size} B`
-  }
-
-  const units = ['KB', 'MB', 'GB']
-  let value = size / 1024
-  let unitIndex = 0
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024
-    unitIndex += 1
-  }
-
-  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Erreur mission'
 }

--- a/frontend/health-robot-front/src/routes/map.tsx
+++ b/frontend/health-robot-front/src/routes/map.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { Compass, Crosshair, HardDrive, Layers3, Loader2, MapPinned, Play, RefreshCw, Save, Trash2 } from 'lucide-react'
+import { Compass, Crosshair, HardDrive, Loader2, MapPinned, Package, Play, Plus, RefreshCw, Save, Trash2 } from 'lucide-react'
 
+import { MissionMapView } from '@/components/mission-map-view'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { RobotKeyboardTeleop } from '@/components/robot-keyboard-teleop'
 import { useAuth } from '@/contexts/AuthContext'
@@ -9,20 +10,44 @@ import { ApiError } from '@/lib/api'
 import { canUseAdminControls, CAREGIVER_OR_ADMIN_ROLES } from '@/lib/permissions'
 import {
   deleteSavedRobotMap,
+  createAnnotatedPoint,
+  deactivateAnnotatedPoint,
+  fetchAnnotatedPoints,
   fetchCurrentRobotMap,
   fetchRobotMapMode,
   fetchSavedRobotMaps,
+  fetchStockPointSupplies,
   loadSavedRobotMap,
   saveCurrentRobotMap,
   setPoseOrigin,
   startMappingMode,
+  updateAnnotatedPoint,
+  updateStockPointSupplies,
+  type AnnotatedPoint,
+  type AnnotatedPointType,
   type RobotMapSnapshot,
   type SavedRobotMap,
+  type StockPointSupply,
+  type SupplyType,
 } from '@/lib/robot-api'
 import { useRobot } from '@/lib/robot-context'
 import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/map')({ component: MapRoute })
+
+const POINT_TYPE_OPTIONS: { value: AnnotatedPointType; label: string }[] = [
+  { value: 'STOCK', label: 'Stock' },
+  { value: 'DELIVERY_ROOM', label: 'Chambre de livraison' },
+  { value: 'ROBOT_BASE', label: 'Base robot' },
+]
+
+const SUPPLY_OPTIONS: { value: SupplyType; label: string }[] = [
+  { value: 'serviettes', label: 'Serviettes' },
+  { value: 'papier_toilette', label: 'Papier toilette' },
+  { value: 'gants', label: 'Gants' },
+  { value: 'protections', label: 'Protections' },
+  { value: 'linge', label: 'Linge' },
+]
 
 function MapRoute() {
   return (
@@ -36,6 +61,7 @@ function MapPage() {
   const { user } = useAuth()
   const { backendStatus, statusError, refreshStatus } = useRobot()
   const [currentMap, setCurrentMap] = useState<RobotMapSnapshot | null>(null)
+  const [annotatedPoints, setAnnotatedPoints] = useState<AnnotatedPoint[]>([])
   const [savedMaps, setSavedMaps] = useState<SavedRobotMap[]>([])
   const [modeState, setModeState] = useState<Record<string, unknown> | null>(null)
   const [mapName, setMapName] = useState(defaultMapName)
@@ -76,12 +102,19 @@ function MapPage() {
         throw modeResult.reason
       }
 
+      await refreshAnnotatedPoints()
+
       setError('')
     } catch (refreshError) {
       setError(getErrorMessage(refreshError))
     } finally {
       setIsLoading(false)
     }
+  }
+
+  const refreshAnnotatedPoints = async () => {
+    const points = await fetchAnnotatedPoints()
+    setAnnotatedPoints(points)
   }
 
   useEffect(() => {
@@ -177,7 +210,7 @@ function MapPage() {
             </div>
 
             <div className="mt-5 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/80 p-3">
-              <OccupancyGridView map={currentMap} pose={backendStatus?.pose ?? null} />
+              <MissionMapView map={currentMap} pose={backendStatus?.pose ?? null} points={annotatedPoints} />
             </div>
           </article>
         </div>
@@ -201,6 +234,8 @@ function MapPage() {
           </article>
 
           <RobotKeyboardTeleop isAdmin={isAdmin} />
+
+          <AnnotatedPointsPanel isAdmin={isAdmin} robotPose={backendStatus?.pose ?? null} onPointsChanged={refreshAnnotatedPoints} />
 
           <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <h2 className="flex items-center gap-2 text-base font-semibold"><Save className="h-4 w-4 text-emerald-200" /> Construire une carte</h2>
@@ -259,76 +294,268 @@ function MapPage() {
   )
 }
 
-function OccupancyGridView({ map, pose }: { map: RobotMapSnapshot | null; pose: { x: number; y: number; yaw?: number | null } | null }) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+function AnnotatedPointsPanel({ isAdmin, robotPose, onPointsChanged }: { isAdmin: boolean; robotPose: { x: number; y: number; yaw?: number | null } | null; onPointsChanged: () => Promise<void> }) {
+  const [points, setPoints] = useState<AnnotatedPoint[]>([])
+  const [suppliesByStock, setSuppliesByStock] = useState<Record<string, StockPointSupply[]>>({})
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState({ name: '', type: 'DELIVERY_ROOM' as AnnotatedPointType, x: '0', y: '0', yaw: '0', is_active: true })
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  const loadPoints = async () => {
+    setIsLoading(true)
+    try {
+      const nextPoints = await fetchAnnotatedPoints()
+      setPoints(nextPoints)
+      const stockSupplies = await Promise.all(
+        nextPoints
+          .filter((point) => point.type === 'STOCK')
+          .map(async (point) => [point.id, await fetchStockPointSupplies(point.id)] as const),
+      )
+      setSuppliesByStock(Object.fromEntries(stockSupplies))
+      setError('')
+    } catch (loadError) {
+      setError(getErrorMessage(loadError))
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas || !map) return
+    void loadPoints()
+  }, [])
 
-    canvas.width = map.width
-    canvas.height = map.height
-    const context = canvas.getContext('2d')
-    if (!context) return
+  const resetForm = () => {
+    setEditingId(null)
+    setForm({ name: '', type: 'DELIVERY_ROOM', x: '0', y: '0', yaw: '0', is_active: true })
+  }
 
-    const image = context.createImageData(map.width, map.height)
-    for (let screenY = 0; screenY < map.height; screenY += 1) {
-      const sourceY = map.height - 1 - screenY
-      for (let x = 0; x < map.width; x += 1) {
-        const value = map.data[sourceY * map.width + x] ?? -1
-        const offset = (screenY * map.width + x) * 4
-        const [r, g, b] = occupancyColor(value)
-        image.data[offset] = r
-        image.data[offset + 1] = g
-        image.data[offset + 2] = b
-        image.data[offset + 3] = 255
-      }
+  const useRobotPose = () => {
+    if (!robotPose) return
+    setForm((previous) => ({
+      ...previous,
+      x: robotPose.x.toFixed(2),
+      y: robotPose.y.toFixed(2),
+      yaw: (robotPose.yaw ?? 0).toFixed(2),
+    }))
+  }
+
+  const submitPoint = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const x = Number(form.x)
+    const y = Number(form.y)
+    const yaw = Number(form.yaw)
+    if (!form.name.trim() || !Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(yaw)) {
+      setError('Renseigne un nom et des coordonnées numériques.')
+      return
     }
-    context.putImageData(image, 0, 0)
 
-    if (pose) {
-      const x = (pose.x - map.origin_x) / map.resolution
-      const y = map.height - (pose.y - map.origin_y) / map.resolution
-      if (x >= 0 && x <= map.width && y >= 0 && y <= map.height) {
-        context.save()
-        context.fillStyle = '#34d399'
-        context.strokeStyle = '#ecfeff'
-        context.lineWidth = Math.max(1, Math.min(map.width, map.height) / 90)
-        context.beginPath()
-        context.arc(x, y, Math.max(2, Math.min(map.width, map.height) / 35), 0, Math.PI * 2)
-        context.fill()
-        context.stroke()
-        const yaw = pose.yaw ?? 0
-        const length = Math.max(5, Math.min(map.width, map.height) / 12)
-        context.beginPath()
-        context.moveTo(x, y)
-        context.lineTo(x + Math.cos(yaw) * length, y - Math.sin(yaw) * length)
-        context.stroke()
-        context.restore()
+    setMessage('')
+    setError('')
+    setIsSaving(true)
+    try {
+      const payload = { name: form.name.trim(), type: form.type, x, y, yaw, is_active: form.is_active }
+      if (editingId) {
+        await updateAnnotatedPoint(editingId, payload)
+        setMessage('Point annoté mis à jour')
+      } else {
+        await createAnnotatedPoint(payload)
+        setMessage('Point annoté créé')
       }
+      resetForm()
+      await loadPoints()
+      await onPointsChanged()
+    } catch (saveError) {
+      setError(getErrorMessage(saveError))
+    } finally {
+      setIsSaving(false)
     }
-  }, [map, pose])
+  }
 
-  if (!map) {
-    return (
-      <div className="flex aspect-[4/3] items-center justify-center rounded-2xl border border-dashed border-white/10 bg-slate-950/60 p-8 text-center text-sm text-slate-400">
-        <div>
-          <Layers3 className="mx-auto mb-3 h-12 w-12 text-slate-500" />
-          <p className="font-semibold text-white">Aucune OccupancyGrid reçue</p>
-          <p className="mt-2">Démarre le mode mapping ou attends que le robot publie `/map`.</p>
-        </div>
-      </div>
-    )
+  const editPoint = (point: AnnotatedPoint) => {
+    setEditingId(point.id)
+    setForm({
+      name: point.name,
+      type: point.type,
+      x: String(point.x),
+      y: String(point.y),
+      yaw: String(point.yaw),
+      is_active: point.is_active,
+    })
+  }
+
+  const deactivatePoint = async (point: AnnotatedPoint) => {
+    if (!window.confirm(`Désactiver le point "${point.name}" ?`)) return
+    setIsSaving(true)
+    setMessage('')
+    setError('')
+    try {
+      await deactivateAnnotatedPoint(point.id)
+      setMessage('Point désactivé')
+      await loadPoints()
+      await onPointsChanged()
+    } catch (deactivateError) {
+      setError(getErrorMessage(deactivateError))
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   return (
-    <canvas
-      ref={canvasRef}
-      className="h-auto max-h-[68vh] w-full rounded-xl bg-slate-950 [image-rendering:pixelated]"
-      style={{ aspectRatio: `${map.width} / ${map.height}` }}
-      aria-label="Carte occupancy grid du robot"
-    />
+    <article className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-base font-semibold"><Package className="h-4 w-4 text-emerald-200" /> Points mission</h2>
+          <p className="mt-2 text-sm text-slate-400">Stocks, chambres et base robot utilisés par le contrôle mission.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadPoints()}
+          disabled={isLoading || isSaving}
+          className="inline-flex items-center rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-white transition hover:bg-white/10 disabled:opacity-50"
+        >
+          {isLoading ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-2 h-3.5 w-3.5" />}
+          Points
+        </button>
+      </div>
+
+      {(message || error) && (
+        <div className={cn('mt-4 rounded-2xl border p-3 text-sm', message && 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100', error && 'border-rose-400/30 bg-rose-400/10 text-rose-100')}>
+          {error || message}
+        </div>
+      )}
+
+      {isAdmin ? (
+        <form className="mt-5 space-y-3" onSubmit={submitPoint}>
+          <label className="block space-y-2 text-sm">
+            <span className="text-slate-300">Nom</span>
+            <input value={form.name} onChange={(event) => setForm((previous) => ({ ...previous, name: event.target.value }))} className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white" />
+          </label>
+          <label className="block space-y-2 text-sm">
+            <span className="text-slate-300">Type</span>
+            <select value={form.type} onChange={(event) => setForm((previous) => ({ ...previous, type: event.target.value as AnnotatedPointType }))} className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-white">
+              {POINT_TYPE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+          <div className="grid grid-cols-3 gap-2">
+            <CoordinateField label="X" value={form.x} onChange={(value) => setForm((previous) => ({ ...previous, x: value }))} />
+            <CoordinateField label="Y" value={form.y} onChange={(value) => setForm((previous) => ({ ...previous, y: value }))} />
+            <CoordinateField label="Yaw" value={form.yaw} onChange={(value) => setForm((previous) => ({ ...previous, yaw: value }))} />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-slate-300">
+            <input type="checkbox" checked={form.is_active} onChange={(event) => setForm((previous) => ({ ...previous, is_active: event.target.checked }))} className="h-4 w-4 accent-cyan-300" />
+            Actif
+          </label>
+          <div className="flex flex-wrap gap-2">
+            <button type="button" onClick={useRobotPose} disabled={!robotPose || isSaving} className="rounded-2xl border border-cyan-400/20 bg-cyan-400/10 px-3 py-2 text-xs font-semibold text-cyan-100 transition hover:bg-cyan-400/20 disabled:opacity-50">
+              Utiliser pose robot
+            </button>
+            <button type="submit" disabled={isSaving} className="inline-flex items-center rounded-2xl bg-emerald-400 px-4 py-2 text-xs font-bold text-slate-950 transition hover:bg-emerald-300 disabled:opacity-50">
+              {isSaving ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : <Plus className="mr-2 h-3.5 w-3.5" />}
+              {editingId ? 'Mettre à jour' : 'Créer'}
+            </button>
+            {editingId && <button type="button" onClick={resetForm} className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-white">Annuler édition</button>}
+          </div>
+        </form>
+      ) : (
+        <p className="mt-4 rounded-2xl border border-amber-400/20 bg-amber-400/10 p-3 text-sm text-amber-100">La création et la modification des points sont réservées aux administrateurs.</p>
+      )}
+
+      <div className="mt-5 space-y-3">
+        {points.length === 0 && <p className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-center text-sm text-slate-400">Aucun point annoté.</p>}
+        {points.map((point) => (
+          <div key={point.id} className={cn('rounded-2xl border p-3', point.is_active ? 'border-white/10 bg-slate-950/40' : 'border-white/5 bg-slate-950/20 opacity-60')}>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-semibold text-white">{point.name}</p>
+                <p className="mt-1 text-xs text-slate-400">{formatPointType(point.type)} · {point.x.toFixed(2)}, {point.y.toFixed(2)}, yaw {point.yaw.toFixed(2)}</p>
+              </div>
+              <span className={cn('rounded-full px-2 py-1 text-[10px] font-bold', point.is_active ? 'bg-emerald-400/10 text-emerald-100' : 'bg-slate-400/10 text-slate-300')}>{point.is_active ? 'actif' : 'inactif'}</span>
+            </div>
+            {isAdmin && (
+              <div className="mt-3 flex gap-2">
+                <button type="button" onClick={() => editPoint(point)} disabled={isSaving} className="rounded-xl border border-cyan-400/20 bg-cyan-400/10 px-3 py-2 text-xs font-bold text-cyan-100 disabled:opacity-50">Éditer</button>
+                <button type="button" onClick={() => void deactivatePoint(point)} disabled={isSaving || !point.is_active} className="rounded-xl border border-rose-400/20 bg-rose-400/10 px-3 py-2 text-xs font-bold text-rose-100 disabled:opacity-50">Désactiver</button>
+              </div>
+            )}
+            {point.type === 'STOCK' && (
+              <StockSupplyEditor point={point} supplies={suppliesByStock[point.id] ?? []} disabled={!isAdmin || isSaving} onSaved={loadPoints} />
+            )}
+          </div>
+        ))}
+      </div>
+    </article>
   )
+}
+
+function StockSupplyEditor({ point, supplies, disabled, onSaved }: { point: AnnotatedPoint; supplies: StockPointSupply[]; disabled: boolean; onSaved: () => Promise<void> }) {
+  const [selected, setSelected] = useState<Record<SupplyType, boolean>>(() => supplySelectionFrom(supplies))
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setSelected(supplySelectionFrom(supplies))
+  }, [supplies])
+
+  const saveSupplies = async () => {
+    setIsSaving(true)
+    setError('')
+    try {
+      await updateStockPointSupplies(
+        point.id,
+        SUPPLY_OPTIONS.filter((option) => selected[option.value]).map((option, index) => ({ supply_type: option.value, priority_order: index + 1, is_active: true })),
+      )
+      await onSaved()
+    } catch (saveError) {
+      setError(getErrorMessage(saveError))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="mt-3 rounded-xl border border-emerald-400/10 bg-emerald-400/5 p-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100">Fournitures stock</p>
+      <div className="mt-3 grid gap-2">
+        {SUPPLY_OPTIONS.map((option) => (
+          <label key={option.value} className="flex items-center gap-2 text-xs text-slate-200">
+            <input
+              type="checkbox"
+              checked={Boolean(selected[option.value])}
+              disabled={disabled || isSaving}
+              onChange={(event) => setSelected((previous) => ({ ...previous, [option.value]: event.target.checked }))}
+              className="h-4 w-4 accent-emerald-300 disabled:opacity-50"
+            />
+            {option.label}
+          </label>
+        ))}
+      </div>
+      {error && <p className="mt-3 rounded-xl border border-rose-400/20 bg-rose-400/10 p-2 text-xs text-rose-100">{error}</p>}
+      <button type="button" disabled={disabled || isSaving} onClick={() => void saveSupplies()} className="mt-3 inline-flex items-center rounded-xl border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs font-bold text-emerald-100 disabled:opacity-50">
+        {isSaving ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-2 h-3.5 w-3.5" />}
+        Enregistrer fournitures
+      </button>
+    </div>
+  )
+}
+
+function CoordinateField({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="text-slate-300">{label}</span>
+      <input type="number" step="0.01" value={value} onChange={(event) => onChange(event.target.value)} className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-3 py-2 text-white" />
+    </label>
+  )
+}
+
+function supplySelectionFrom(supplies: StockPointSupply[]) {
+  return Object.fromEntries(SUPPLY_OPTIONS.map((option) => [option.value, supplies.some((supply) => supply.supply_type === option.value && supply.is_active)])) as Record<SupplyType, boolean>
+}
+
+function formatPointType(type: AnnotatedPointType) {
+  return POINT_TYPE_OPTIONS.find((option) => option.value === type)?.label ?? type
 }
 
 function SavedMapRow({ map, disabled, onLoad, onDelete }: { map: SavedRobotMap; disabled: boolean; onLoad: () => void; onDelete: () => void }) {
@@ -384,13 +611,6 @@ function InfoRow({ label, value }: { label: string; value: string }) {
       <span className="font-mono text-sm text-white">{value}</span>
     </div>
   )
-}
-
-function occupancyColor(value: number): [number, number, number] {
-  if (value < 0) return [30, 41, 59]
-  if (value === 0) return [226, 232, 240]
-  const shade = Math.max(15, 210 - value * 1.8)
-  return [shade, shade, shade]
 }
 
 function defaultMapName() {

--- a/frontend/health-robot-front/src/routes/robot-screen.tsx
+++ b/frontend/health-robot-front/src/routes/robot-screen.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { AlertTriangle, Loader2, PackageCheck, RefreshCw } from 'lucide-react'
+
+import { fetchRobotScreenStatus, type RobotScreenStatus } from '@/lib/robot-api'
+import { cn } from '@/lib/utils'
+
+export const Route = createFileRoute('/robot-screen')({ component: RobotScreenRoute })
+
+const TOKEN_STORAGE_KEY = 'health-robot-front:robot-screen-token'
+
+function RobotScreenRoute() {
+  const [token, setToken] = useState(() => readStoredToken())
+  const [tokenInput, setTokenInput] = useState('')
+  const [status, setStatus] = useState<RobotScreenStatus | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const loadStatus = async (currentToken = token) => {
+    if (!currentToken) return
+    setIsLoading(true)
+    try {
+      const nextStatus = await fetchRobotScreenStatus(currentToken)
+      setStatus(nextStatus)
+      setError('')
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Écran robot indisponible')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!token) return
+    void loadStatus(token)
+    const interval = window.setInterval(() => {
+      void loadStatus(token)
+    }, 2000)
+    return () => window.clearInterval(interval)
+  }, [token])
+
+  const submitToken = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextToken = tokenInput.trim()
+    if (!nextToken) return
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, nextToken)
+    setToken(nextToken)
+    setTokenInput('')
+  }
+
+  const resetToken = () => {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY)
+    setToken(null)
+    setStatus(null)
+    setError('')
+  }
+
+  const robotState = status?.robot_state ?? 'IDLE'
+  const isIdle = robotState === 'IDLE'
+
+  if (!token) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 px-4 text-white">
+        <form onSubmit={submitToken} className="w-full max-w-md rounded-[2rem] border border-white/10 bg-white/5 p-8 shadow-2xl shadow-cyan-950/20 backdrop-blur">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200">CareBot</p>
+          <h1 className="mt-3 text-3xl font-black">Écran robot</h1>
+          <p className="mt-3 text-sm text-slate-400">Saisis le token dédié à l'écran robot. Il sera stocké localement sur cet appareil.</p>
+          <label className="mt-6 block space-y-2 text-sm">
+            <span className="text-slate-300">Robot screen token</span>
+            <input type="password" value={tokenInput} onChange={(event) => setTokenInput(event.target.value)} className="w-full rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-white" autoFocus />
+          </label>
+          <button type="submit" disabled={!tokenInput.trim()} className="mt-5 w-full rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">
+            Connecter l'écran
+          </button>
+        </form>
+      </main>
+    )
+  }
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_80%_0%,rgba(16,185,129,0.16),transparent_30%)]" />
+      <div className="relative flex min-h-screen flex-col px-6 py-6 sm:px-10">
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.4em] text-cyan-200">CareBot</p>
+            <h1 className="mt-2 text-3xl font-black sm:text-5xl">Écran robot</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            {isLoading && <Loader2 className="h-5 w-5 animate-spin text-cyan-200" />}
+            <button type="button" onClick={() => void loadStatus()} className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/10">
+              <RefreshCw className="h-4 w-4" />
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="mt-6 flex items-start gap-3 rounded-3xl border border-rose-400/30 bg-rose-400/10 p-4 text-rose-100">
+            <AlertTriangle className="mt-0.5 h-5 w-5" />
+            <p>{error}</p>
+          </div>
+        )}
+
+        <section className="flex flex-1 items-center justify-center py-10">
+          <div className="w-full max-w-5xl rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-center shadow-2xl shadow-cyan-950/20 backdrop-blur sm:p-12">
+            <div className={cn('mx-auto mb-8 flex h-24 w-24 items-center justify-center rounded-full border', robotState === 'EMERGENCY_STOP' ? 'border-rose-300/40 bg-rose-400/15 text-rose-100' : isIdle ? 'border-emerald-300/40 bg-emerald-400/15 text-emerald-100' : 'border-cyan-300/30 bg-cyan-400/15 text-cyan-100')}>
+              {robotState === 'EMERGENCY_STOP' ? <AlertTriangle className="h-12 w-12" /> : <PackageCheck className="h-12 w-12" />}
+            </div>
+            <p className={cn('text-xl font-semibold uppercase tracking-[0.25em]', isIdle ? 'text-emerald-100/90' : 'text-cyan-100/80')}>{isIdle ? 'IDLE / PRÊT' : robotState}</p>
+            <h2 className="mt-5 text-4xl font-black leading-tight sm:text-7xl">{isIdle ? 'CareBot' : status?.screen_title_fr ?? 'CareBot'}</h2>
+            <p className="mx-auto mt-6 max-w-3xl text-2xl leading-relaxed text-slate-100/85 sm:text-3xl">{status?.screen_message_fr ?? 'Chargement de l’état mission...'}</p>
+
+            {status?.current_mission && (
+              <div className="mx-auto mt-10 grid max-w-3xl gap-4 rounded-3xl border border-white/10 bg-slate-950/50 p-5 text-left sm:grid-cols-2">
+                <Info label="Fourniture" value={status.current_mission.supply_label_fr} />
+                <Info label="Destination" value={status.current_mission.destination_label_fr} />
+                <Info label="Mission" value={status.current_mission.id} mono />
+                <Info label="Statut" value={status.current_mission.status} mono />
+              </div>
+            )}
+          </div>
+        </section>
+
+        <footer className="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
+          <span>Mis à jour: {status?.updated_at ? new Date(status.updated_at).toLocaleTimeString() : 'en attente'}</span>
+          <button type="button" onClick={resetToken} className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-slate-300 transition hover:bg-white/10">Changer token</button>
+        </footer>
+      </div>
+    </main>
+  )
+}
+
+function Info({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">{label}</p>
+      <p className={cn('mt-2 text-lg font-semibold text-white', mono && 'font-mono text-sm')}>{value}</p>
+    </div>
+  )
+}
+
+function readStoredToken() {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  return window.localStorage.getItem(TOKEN_STORAGE_KEY)
+}


### PR DESCRIPTION
… robot screen

Backend:
- Add mission domain entity with state machine (pending/active/completed/cancelled)
- Add mission orchestrator for state transitions
- Add annotated point repository for stock/delivery locations
- Add mission and annotated point API endpoints
- Add robot screen token-based auth endpoint
- Add Alembic migration for mission_control tables
- Update emergency handling for mission integration

Frontend:
- Add mission map view component
- Add robot screen route (French labels, token auth)
- Update control page for mission workflow
- Update map page for annotated points management
- Update robot API client with mission endpoints

Docs:
- Add mission control implementation plan
- Add domain glossary (CONTEXT_MISSION.md)